### PR TITLE
Passes the charmcraft token as a variable to the publish workflow

### DIFF
--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -2,6 +2,10 @@ name: publish-charm
 
 on:
   workflow_call:
+    inputs:
+      charmcraft-token:
+        required: true
+        type: string
 
 jobs:
   publish-charm:
@@ -22,5 +26,5 @@ jobs:
         id: channel
       - name: Upload charm to Charmhub
         env:
-          CHARMCRAFT_AUTH: "${{ secrets.CHARMCRAFT_AUTH }}"
+          CHARMCRAFT_AUTH: ${{ inputs.charmcraft-token }}
         run: charmcraft upload ./self-signed-certificates_ubuntu-22.04-amd64.charm --release ${{ steps.channel.outputs.name }}

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -2,10 +2,9 @@ name: publish-charm
 
 on:
   workflow_call:
-    inputs:
-      charmcraft-token:
+    secrets:
+      CHARMCRAFT_AUTH:
         required: true
-        type: string
 
 jobs:
   publish-charm:
@@ -26,5 +25,5 @@ jobs:
         id: channel
       - name: Upload charm to Charmhub
         env:
-          CHARMCRAFT_AUTH: ${{ inputs.charmcraft-token }}
+          CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
         run: charmcraft upload ./self-signed-certificates_ubuntu-22.04-amd64.charm --release ${{ steps.channel.outputs.name }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -22,3 +22,5 @@ jobs:
       [lint-report, static-analysis, unit-tests-with-coverage, integration-test]
     if: ${{ github.ref_name == 'main' }}
     uses: ./.github/workflows/publish-charm.yaml
+    with:
+      charmcraft-token: ${{ secrets.CHARMCRAFT_AUTH }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -22,5 +22,5 @@ jobs:
       [lint-report, static-analysis, unit-tests-with-coverage, integration-test]
     if: ${{ github.ref_name == 'main' }}
     uses: ./.github/workflows/publish-charm.yaml
-    with:
-      charmcraft-token: ${{ secrets.CHARMCRAFT_AUTH }}
+    secrets:
+      CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}


### PR DESCRIPTION
# Description

Passes the charmcraft token as a variable to the publish workflow.

Reason: Environment Secrets are not available on Reusable Workflow

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
