### PR TITLE
[chore] Uses LXD 5.13 for integration tests

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@main
         with:
-          channel: 5.12/stable
+          channel: 5.13/stable
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:


### PR DESCRIPTION
# Description

Uses LXD 5.13 for integration tests. Integration tests were crashing because the snap for 5.12 is not available anymore.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
