### PR TITLE
[Bug fix] Checks that ca certificate secret already exists before creating it

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@main
         with:
-          channel: 5.12/stable
+          channel: 5.13/stable
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/src/charm.py
+++ b/src/charm.py
@@ -51,8 +51,8 @@ class SelfSignedCertificatesCharm(CharmBase):
     def _config_ca_common_name(self) -> Optional[str]:
         """Returns the user provided common name.
 
-         This common name should only be used when the 'generate-self-signed-certificates' config
-         is set to True.
+        This common name should only be used when the
+        'generate-self-signed-certificates' config is set to True.
 
         Returns:
             str: Common name
@@ -73,7 +73,11 @@ class SelfSignedCertificatesCharm(CharmBase):
             return False
 
     def _generate_root_certificate(self) -> None:
-        """Generates root certificate to be used to sign certificates."""
+        """Generates root certificate to be used to sign certificates.
+
+        If the secretis already created, we simply update its content, else we
+        create a new secret.
+        """
         if not self._config_ca_common_name:
             raise ValueError("CA common name should not be empty")
         private_key_password = generate_password()
@@ -83,14 +87,19 @@ class SelfSignedCertificatesCharm(CharmBase):
             subject=self._config_ca_common_name,
             private_key_password=private_key_password.encode(),
         )
-        self.app.add_secret(
-            content={
-                "private-key-password": private_key_password,
-                "private-key": private_key.decode(),
-                "ca-certificate": ca_certificate.decode(),
-            },
-            label=CA_CERTIFICATES_SECRET_LABEL,
-        )
+        secret_content = {
+            "private-key-password": private_key_password,
+            "private-key": private_key.decode(),
+            "ca-certificate": ca_certificate.decode(),
+        }
+        if self._root_certificate_is_stored:
+            secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
+            secret.set_content(content=secret_content)
+        else:
+            self.app.add_secret(
+                content=secret_content,
+                label=CA_CERTIFICATES_SECRET_LABEL,
+            )
         logger.info("Root certificates generated and stored.")
 
     def _on_config_changed(self, event: ConfigChangedEvent) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -51,8 +51,8 @@ class SelfSignedCertificatesCharm(CharmBase):
     def _config_ca_common_name(self) -> Optional[str]:
         """Returns the user provided common name.
 
-        This common name should only be used when the
-        'generate-self-signed-certificates' config is set to True.
+         This common name should only be used when the 'generate-self-signed-certificates' config
+         is set to True.
 
         Returns:
             str: Common name
@@ -75,8 +75,8 @@ class SelfSignedCertificatesCharm(CharmBase):
     def _generate_root_certificate(self) -> None:
         """Generates root certificate to be used to sign certificates.
 
-        If the secretis already created, we simply update its content, else we
-        create a new secret.
+        If the secret is already created, we simply update its content, else we create a
+        new secret.
         """
         if not self._config_ca_common_name:
             raise ValueError("CA common name should not be empty")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -173,7 +173,7 @@ class TestCharm(unittest.TestCase):
     @patch("charm.generate_private_key")
     @patch("charm.generate_password")
     @patch("charm.generate_ca")
-    def test_given_when_then(
+    def test_given_initial_config_when_config_changed_then_stored_ca_common_name_uses_new_config(
         self,
         patch_generate_ca,
         patch_generate_password,
@@ -196,7 +196,9 @@ class TestCharm(unittest.TestCase):
         patch_generate_private_key.side_effect = [private_key_bytes_1, private_key_bytes_2]
         self.harness.set_leader(is_leader=True)
         self.harness.update_config(key_values={"ca-common-name": initial_common_name})
+
         self.harness.update_config(key_values={"ca-common-name": new_common_name})
+
         ca_certificates_secret = self.harness._backend.secret_get(label="ca-certificates")
         self.assertEqual(
             ca_certificates_secret["ca-certificate"],

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -169,3 +169,44 @@ class TestCharm(unittest.TestCase):
             relation_id=relation_id,
             certificate_signing_request=certificate_signing_request,
         )
+
+    @patch("charm.generate_private_key")
+    @patch("charm.generate_password")
+    @patch("charm.generate_ca")
+    def test_given_when_then(
+        self,
+        patch_generate_ca,
+        patch_generate_password,
+        patch_generate_private_key,
+    ):
+        initial_common_name = "common-name-initial.com"
+        new_common_name = "common-name-new.com"
+        ca_certificate_1_string = "whatever CA certificate 1"
+        ca_certificate_2_string = "whatever CA certificate 2"
+        private_key_string_1 = "whatever private key 1"
+        private_key_string_2 = "whatever private key 2"
+        private_key_password_1 = "banana"
+        private_key_password_2 = "apple"
+        ca_certificate_bytes_1 = ca_certificate_1_string.encode()
+        ca_certificate_bytes_2 = ca_certificate_2_string.encode()
+        private_key_bytes_1 = private_key_string_1.encode()
+        private_key_bytes_2 = private_key_string_2.encode()
+        patch_generate_ca.side_effect = [ca_certificate_bytes_1, ca_certificate_bytes_2]
+        patch_generate_password.side_effect = [private_key_password_1, private_key_password_2]
+        patch_generate_private_key.side_effect = [private_key_bytes_1, private_key_bytes_2]
+        self.harness.set_leader(is_leader=True)
+        self.harness.update_config(key_values={"ca-common-name": initial_common_name})
+        self.harness.update_config(key_values={"ca-common-name": new_common_name})
+        ca_certificates_secret = self.harness._backend.secret_get(label="ca-certificates")
+        self.assertEqual(
+            ca_certificates_secret["ca-certificate"],
+            ca_certificate_2_string,
+        )
+        self.assertEqual(
+            ca_certificates_secret["private-key-password"],
+            private_key_password_2,
+        )
+        self.assertEqual(
+            ca_certificates_secret["private-key"],
+            private_key_string_2,
+        )


### PR DESCRIPTION
# Description

Checks that ca certificate secret already exists before creating it. This fixes bug where charm would crash on follow-up config changed events. Fixes #7 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
