### PR TITLE
Skeleton for action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,2 @@
+get-issued-certificates:
+  description: Outputs issue certificates.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -12,9 +12,5 @@ bases:
 
 parts:
   charm:
-    build-packages:
-      - libffi-dev
-      - libssl-dev
-      - rustc
-      - cargo
-      - pkg-config
+    charm-binary-python-packages: [cryptography, jsonschema, ops]
+

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,8 +15,7 @@ from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ign
     generate_certificate,
     generate_private_key,
 )
-from ops.charm import CharmBase, ConfigChangedEvent
-from ops.charm import ActionEvent
+from ops.charm import ActionEvent, CharmBase, ConfigChangedEvent
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, SecretNotFoundError, WaitingStatus
 
@@ -38,12 +37,22 @@ class SelfSignedCertificatesCharm(CharmBase):
             self.tls_certificates.on.certificate_creation_request,
             self._on_certificate_creation_request,
         )
-        
-        self.framework.observe(self.on.get_issued_certificates_action, self._on_get_issued_certificates)
-        
+
+        self.framework.observe(
+            self.on.get_issued_certificates_action, self._on_get_issued_certificates
+        )
+
     def _on_get_issued_certificates(self, event: ActionEvent) -> None:
-        """Outputs issued certificates by using a Juju action."""
-        msg = "Trying action..."
+        """Outputs issued certificates by using a Juju action.
+        
+        Returns:
+            event (ActionEvent): Juju event.
+        """
+        relations_data = []
+        for relation in self.model.relations.get("certificates", []):
+            if data := relation.data.get(self.app):
+                relations_data.append(data)
+        msg = str(relations_data)
         event.set_results({"result": msg})
 
     @property

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,6 +16,7 @@ from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ign
     generate_private_key,
 )
 from ops.charm import CharmBase, ConfigChangedEvent
+from ops.charm import ActionEvent
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, SecretNotFoundError, WaitingStatus
 
@@ -37,6 +38,13 @@ class SelfSignedCertificatesCharm(CharmBase):
             self.tls_certificates.on.certificate_creation_request,
             self._on_certificate_creation_request,
         )
+        
+        self.framework.observe(self.on.get_issued_certificates_action, self._on_get_issued_certificates)
+        
+    def _on_get_issued_certificates(self, event: ActionEvent) -> None:
+        """Outputs issued certificates by using a Juju action."""
+        msg = "Trying action..."
+        event.set_results({"result": msg})
 
     @property
     def _config_certificate_validity(self) -> int:


### PR DESCRIPTION
# Description

Adds a Juju action named `get-issued-certificates` which outputs the certificates issued by the charm.

Fixes #9

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
- [ ] Check if possible change `event.set_results({"result": msg})` to `event.set_results({"app-1": data})`
