### PR TITLE
Adds logic for Root CA renewal

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,10 @@ options:
     type: string
     default: self-signed-certificates-operator
     description: Common name to be used by the Certificate Authority.
+  root-ca-validity:
+    type: int
+    default: 365
+    description: RootCA certificate validity (in days).
   certificate-validity:
     type: int
     default: 365

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,7 +7,7 @@
 import datetime
 import logging
 import secrets
-from typing import Optional, Union
+from typing import Optional
 
 from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ignore[import]
     CertificateCreationRequestEvent,
@@ -16,7 +16,7 @@ from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ign
     generate_certificate,
     generate_private_key,
 )
-from ops.charm import CharmBase, ConfigChangedEvent, SecretExpiredEvent
+from ops.charm import CharmBase, EventBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, SecretNotFoundError, WaitingStatus
 
@@ -115,13 +115,13 @@ class SelfSignedCertificatesCharm(CharmBase):
             )
         logger.info("Root certificates generated and stored.")
 
-    def _configure_ca(self, event: Union[ConfigChangedEvent, SecretExpiredEvent]) -> None:
+    def _configure_ca(self, event: EventBase) -> None:
         """Validates configuration and generates root certificate.
 
         It will revoke the certificates signed by the previous root certificate.
 
         Args:
-            event: Union[ConfigChangedEvent, SecretExpiredEvent]
+            event (EventBase): Juju event
         """
         if not self.unit.is_leader():
             return
@@ -154,7 +154,7 @@ class SelfSignedCertificatesCharm(CharmBase):
         """Handler for certificate requests.
 
         Args:
-            event: CertificateCreationRequestEvent
+            event (CertificateCreationRequestEvent): Jujue event
         """
         if not self.unit.is_leader():
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -4,9 +4,10 @@
 
 """Self Signed X.509 Certificates."""
 
+import datetime
 import logging
 import secrets
-from typing import Optional
+from typing import Optional, Union
 
 from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ignore[import]
     CertificateCreationRequestEvent,
@@ -15,7 +16,7 @@ from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ign
     generate_certificate,
     generate_private_key,
 )
-from ops.charm import CharmBase, ConfigChangedEvent
+from ops.charm import CharmBase, ConfigChangedEvent, SecretExpiredEvent
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, SecretNotFoundError, WaitingStatus
 
@@ -32,11 +33,21 @@ class SelfSignedCertificatesCharm(CharmBase):
         """Observes config change and certificate request events."""
         super().__init__(*args)
         self.tls_certificates = TLSCertificatesProvidesV2(self, "certificates")
-        self.framework.observe(self.on.config_changed, self._on_config_changed)
+        self.framework.observe(self.on.config_changed, self._configure_ca)
         self.framework.observe(
             self.tls_certificates.on.certificate_creation_request,
             self._on_certificate_creation_request,
         )
+        self.framework.observe(self.on.secret_expired, self._configure_ca)
+
+    @property
+    def _config_root_ca_certificate_validity(self) -> int:
+        """Returns Root CA certificate validity (in days).
+
+        Returns:
+            int: Certificate validity (in days)
+        """
+        return int(self.model.config.get("root-ca-validity"))  # type: ignore[arg-type]
 
     @property
     def _config_certificate_validity(self) -> int:
@@ -45,7 +56,7 @@ class SelfSignedCertificatesCharm(CharmBase):
         Returns:
             int: Certificate validity (in days)
         """
-        return int(self.model.config.get("certificate-validity", 365))
+        return int(self.model.config.get("certificate-validity"))  # type: ignore[arg-type]
 
     @property
     def _config_ca_common_name(self) -> Optional[str]:
@@ -75,6 +86,7 @@ class SelfSignedCertificatesCharm(CharmBase):
     def _generate_root_certificate(self) -> None:
         """Generates root certificate to be used to sign certificates.
 
+        Stores the root certificate in a juju secret.
         If the secret is already created, we simply update its content, else we create a
         new secret.
         """
@@ -99,14 +111,17 @@ class SelfSignedCertificatesCharm(CharmBase):
             self.app.add_secret(
                 content=secret_content,
                 label=CA_CERTIFICATES_SECRET_LABEL,
+                expire=datetime.timedelta(days=self._config_certificate_validity),
             )
         logger.info("Root certificates generated and stored.")
 
-    def _on_config_changed(self, event: ConfigChangedEvent) -> None:
-        """Triggered when the Juju config is changed.
+    def _configure_ca(self, event: Union[ConfigChangedEvent, SecretExpiredEvent]) -> None:
+        """Validates configuration and generates root certificate.
+
+        It will revoke the certificates signed by the previous root certificate.
 
         Args:
-            event (ConfigChangedEvent): Juju event.
+            event: Union[ConfigChangedEvent, SecretExpiredEvent]
         """
         if not self.unit.is_leader():
             return
@@ -129,6 +144,8 @@ class SelfSignedCertificatesCharm(CharmBase):
         invalid_configs = []
         if not self._config_ca_common_name:
             invalid_configs.append("ca-common-name")
+        if not self._config_root_ca_certificate_validity:
+            invalid_configs.append("root-ca-validity")
         if not self._config_certificate_validity:
             invalid_configs.append("certificate-validity")
         return invalid_configs

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = lint, unit
+envlist = lint, unit, static
 
 [vars]
 src_path = {toxinidir}/src/


### PR DESCRIPTION
# Description

Handles the expiration of the Juju secret that stores the Root CA, and generates a new one when expired.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
