### PR TITLE
Run the CI on a schedule

### DIFF
--- a/.github/workflows/check-libraries.yaml
+++ b/.github/workflows/check-libraries.yaml
@@ -1,0 +1,16 @@
+name: Check libraries
+
+on:
+  workflow_call:
+    secrets:
+      CHARMCRAFT_AUTH:
+        required: true
+
+jobs:
+  check-libraries:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: canonical/charming-actions/check-libraries@2.3.0
+        with:
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,7 +1,9 @@
-name: Push
+name: Main
 
 on:
   push:
+  schedule:
+    - cron: '0 0 * * 0'
 
 jobs:
   lint-report:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,6 +6,10 @@ on:
     - cron: '0 0 * * 0'
 
 jobs:
+  check-libraries:
+    uses: ./.github/workflows/check-libraries.yaml
+    secrets: inherit
+
   lint-report:
     uses: ./.github/workflows/lint-report.yaml
 

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -20,13 +20,10 @@ jobs:
           name: tested-charm
       - name: Move charm in current directory
         run: find ./ -name self-signed-certificates_ubuntu-22.04-amd64.charm -exec mv -t ./ {} \;
-      - name: Select Charmhub channel
-        uses: canonical/charming-actions/channel@2.3.0
-        id: channel
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.3.0
         with:
           built-charm-path: "self-signed-certificates_ubuntu-22.04-amd64.charm"
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: "${{ steps.channel.outputs.name }}"
+          channel: latest/edge


### PR DESCRIPTION
# Description

Runs the CI on a schedule each week to build and publish the charm.
The CI will run every Sunday at midnight UTC.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
