### PR TITLE
Adds requirer charm to the integration tests

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 
+TLS_REQUIRER_CHARM_NAME = "tls-certificates-requirer"
+
 
 @pytest.fixture(scope="module")
 @pytest.mark.abort_on_fail
@@ -25,6 +27,11 @@ async def build_and_deploy(ops_test):
         application_name=APP_NAME,
         series="jammy",
         trust=True,
+    )
+    await ops_test.model.deploy(
+        TLS_REQUIRER_CHARM_NAME,
+        application_name=TLS_REQUIRER_CHARM_NAME,
+        channel="edge",
     )
 
 
@@ -38,3 +45,39 @@ async def test_given_charm_is_built_when_deployed_then_status_is_active(
         status="active",
         timeout=1000,
     )
+
+
+async def test_given_tls_requirer_is_deployed_and_related_then_certificate_is_created_and_passed_correctly(  # noqa: E501
+    ops_test,
+    build_and_deploy,
+):
+    await ops_test.model.add_relation(
+        relation1=f"{APP_NAME}:certificates", relation2=f"{TLS_REQUIRER_CHARM_NAME}"
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[TLS_REQUIRER_CHARM_NAME],
+        status="active",
+        timeout=1000,
+    )
+    action_output = await run_get_certificate_action(ops_test)
+    assert action_output["certificate"] is not None
+    assert action_output["ca-certificate"] is not None
+    assert action_output["chain"] is not None
+    assert action_output["csr"] is not None
+
+
+async def run_get_certificate_action(ops_test) -> dict:
+    """Runs `get-certificate` on the `tls-requirer-requirer/0` unit.
+
+    Args:
+        ops_test (OpsTest): OpsTest
+
+    Returns:
+        dict: Action output
+    """
+    tls_requirer_unit = ops_test.model.units[f"{TLS_REQUIRER_CHARM_NAME}/0"]
+    action = await tls_requirer_unit.run_action(
+        action_name="get-certificate",
+    )
+    action_output = await ops_test.model.get_action_output(action_uuid=action.entity_id, wait=240)
+    return action_output


### PR DESCRIPTION
# Description

Adds requirer charm to the integration tests:
- Checks if certificate is provided using the get-certificate action of the tls-requirer-operator charm

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
