### PR TITLE
add get_ca action

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ juju deploy self-signed-certificates
 juju deploy <your charm>
 juju relate self-signed-certificates <your charm>
 ```
+
+To get the CA certificate run:
+
+```console
+juju run self-signed-certificates/0 get-ca-cert
+```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ juju relate self-signed-certificates:send-ca-cert <your charm>
 To get the CA certificate run:
 
 ```console
-juju run self-signed-certificates/0 get-ca-cert
+juju run self-signed-certificates/0 get-ca-certificate
 ```
 
 ## Get the certificates issued by the charm

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,2 +1,2 @@
-get-ca-cert:
+get-ca-certificate:
   description: Print the CA cert.

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,2 @@
+get-ca-cert:
+  description: Print the CA cert.

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,7 +16,7 @@ from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ign
     generate_certificate,
     generate_private_key,
 )
-from ops.charm import CharmBase, EventBase
+from ops.charm import ActionEvent, CharmBase, EventBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, SecretNotFoundError, WaitingStatus
 
@@ -39,7 +39,7 @@ class SelfSignedCertificatesCharm(CharmBase):
             self._on_certificate_creation_request,
         )
         self.framework.observe(self.on.secret_expired, self._configure_ca)
-        self.framework.observe(self.on.get_ca_cert_action, self._on_get_ca_cert)
+        self.framework.observe(self.on.get_ca_certificate_action, self._on_get_ca_certificate)
 
     @property
     def _config_root_ca_certificate_validity(self) -> int:
@@ -155,7 +155,7 @@ class SelfSignedCertificatesCharm(CharmBase):
         """Handler for certificate requests.
 
         Args:
-            event (CertificateCreationRequestEvent): Jujue event
+            event (CertificateCreationRequestEvent): Juju event
         """
         if not self.unit.is_leader():
             return
@@ -187,9 +187,14 @@ class SelfSignedCertificatesCharm(CharmBase):
         )
         logger.info(f"Generated certificate for relation {event.relation_id}")
 
-    def _on_get_ca_cert(self, event):
+    def _on_get_ca_certificate(self, event: ActionEvent):
+        """Handler for the get-ca-certificate action.
+
+        Args:
+            event (ActionEvent): Juju event
+        """
         if not self._root_certificate_is_stored:
-            event.set_results({"result": "Root Certificate is not yet generated"})
+            event.set_results({"result": "Root Ccertificate is not yet generated"})
             return
         ca_certificate_secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
         ca_certificate_secret_content = ca_certificate_secret.get_content()

--- a/src/charm.py
+++ b/src/charm.py
@@ -224,11 +224,11 @@ class SelfSignedCertificatesCharm(CharmBase):
             event (ActionEvent): Juju event
         """
         if not self._root_certificate_is_stored:
-            event.fail("Root Ccertificate is not yet generated")
+            event.fail("Root Certificate is not yet generated")
             return
         ca_certificate_secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
         ca_certificate_secret_content = ca_certificate_secret.get_content()
-        event.set_results({"result": ca_certificate_secret_content["ca-certificate"]})
+        event.set_results({"ca-certificate": ca_certificate_secret_content["ca-certificate"]})
 
     def _on_send_ca_cert_relation_joined(self, event: RelationJoinedEvent):
         self._send_ca_cert(rel_id=event.relation.id)

--- a/src/charm.py
+++ b/src/charm.py
@@ -194,7 +194,7 @@ class SelfSignedCertificatesCharm(CharmBase):
             event (ActionEvent): Juju event
         """
         if not self._root_certificate_is_stored:
-            event.set_results({"result": "Root Ccertificate is not yet generated"})
+            event.fail("Root Ccertificate is not yet generated")
             return
         ca_certificate_secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
         ca_certificate_secret_content = ca_certificate_secret.get_content()

--- a/src/charm.py
+++ b/src/charm.py
@@ -253,6 +253,7 @@ class SelfSignedCertificatesCharm(CharmBase):
             for relation in self.model.relations.get(SEND_CA_CERT_REL_NAME, []):
                 send_ca_cert.remove_certificate(relation.id)
 
+
 def generate_password() -> str:
     """Generates a random string containing 64 bytes.
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -172,7 +172,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             self.harness.model.unit.status,
-            WaitingStatus("Root Certificates is not yet generated"),
+            WaitingStatus("Root Certificate is not yet generated"),
         )
 
     @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV2.set_relation_certificate")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -290,3 +290,32 @@ class TestCharm(unittest.TestCase):
         }
 
         action_event.set_results.assert_called_with(expected_certificates)
+
+    def test_given_ca_cert_generated_when_get_ca_certificate_action_then_returns_ca_certificate(
+        self,
+    ):
+        self.harness.set_leader(is_leader=True)
+        ca_certificate = "whatever CA certificate"
+
+        self.harness._backend.secret_add(
+            label="ca-certificates",
+            content={
+                "ca-certificate": ca_certificate,
+                "private-key": "whatever private key",
+                "private-key-password": "whatever private_key_password",
+            },
+        )
+
+        action_event = Mock()
+        self.harness.charm._on_get_ca_certificate(action_event)
+        expected_certificate = {
+            "ca-certificate": ca_certificate,
+        }
+
+        action_event.set_results.assert_called_with(expected_certificate)
+
+    def test_given_ca_cert_not_generated_when_get_ca_certificate_action_then_action_fails(self):
+        self.harness.set_leader(is_leader=True)
+        action_event = Mock(params={})
+        self.harness.charm._on_get_ca_certificate(action_event)
+        action_event.fail.assert_called_with("Root Certificate is not yet generated")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -316,6 +316,6 @@ class TestCharm(unittest.TestCase):
 
     def test_given_ca_cert_not_generated_when_get_ca_certificate_action_then_action_fails(self):
         self.harness.set_leader(is_leader=True)
-        action_event = Mock(params={})
+        action_event = Mock()
         self.harness.charm._on_get_ca_certificate(action_event)
         action_event.fail.assert_called_with("Root Certificate is not yet generated")


### PR DESCRIPTION
# Description

This change adds an action that returns the CA cert. This is needed in order to connect to the charms using certs generated by this charm.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library (No lib changed)
