### PR TITLE
Add send-ca-cert (certificate_transfer) relation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 An operator to provide self-signed X.509 certificates to your charms.
 
-This charm relies on the `tls-certificates` charm relation interface. When a requirer charm 
-inserts a Certificate Signing Request in its unit databag, the 
+This charm relies on the `tls-certificates` charm relation interface. When a requirer charm
+inserts a Certificate Signing Request in its unit databag, the
 `self-signed-certificates-operator` will read it, generate a self-signed X.509 certificates and
 inserts this certificate back into the relation data.
 
@@ -22,6 +22,12 @@ needs to support the `tls-certificates` interface.
 juju deploy self-signed-certificates
 juju deploy <your charm>
 juju relate self-signed-certificates <your charm>
+```
+
+To obtain the CA cert fom this charm, your charm needs to support the `mutual_tls` interface.
+
+```console
+juju relate self-signed-certificates:send-ca-cert <your charm>
 ```
 
 ## Get the certificates issued by the charm

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ juju deploy <your charm>
 juju relate self-signed-certificates <your charm>
 ```
 
-To obtain the CA certificate from this charm, your charm needs to support the `mutual_tls` interface.
+To obtain the CA certificate from this charm, your charm needs to support the
+`certificate_transfer` interface.
 
 ```console
 juju relate self-signed-certificates:send-ca-cert <your charm>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ juju deploy <your charm>
 juju relate self-signed-certificates <your charm>
 ```
 
-To obtain the CA cert fom this charm, your charm needs to support the `mutual_tls` interface.
+To obtain the CA certificate from this charm, your charm needs to support the `mutual_tls` interface.
 
 ```console
 juju relate self-signed-certificates:send-ca-cert <your charm>

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -12,9 +12,14 @@ bases:
 
 parts:
   charm:
-    build-packages:
-      - libffi-dev
-      - libssl-dev
-      - rustc
-      - cargo
-      - pkg-config
+    charm-binary-python-packages:
+      # This is a dev tool, so there is no issue with using binary packages in favor of build time
+      - cryptography
+      - jsonschema
+      - ops >= 2.2.0
+#    build-packages:
+#      - libffi-dev
+#      - libssl-dev
+#      - rustc
+#      - cargo
+#      - pkg-config

--- a/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
@@ -1,19 +1,17 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Library for the mutual-tls relation.
+"""Library for the certificate_transfer relation.
 
-This library contains the Requires and Provides classes for handling the mutual-tls interface.
+This library contains the Requires and Provides classes for handling the
+ertificate-transfer interface.
 
 ## Getting Started
 From a charm directory, fetch the library using `charmcraft`:
 
 ```shell
-charmcraft fetch-lib charms.mutual_tls_interface.v0.mutual_tls
+charmcraft fetch-lib charms.certificate_transfer_interface.v0.certificate_transfer
 ```
-
-Add the following libraries to the charm's `requirements.txt` file:
-- jsonschema
 
 ### Provider charm
 The provider charm is the charm providing public certificates to another charm that requires them.
@@ -23,13 +21,13 @@ Example:
 from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
 
-from lib.charms.mutual_tls_interface.v0.mutual_tls import MutualTLSProvides
+from lib.charms.certificate_transfer_interface.v0.certificate_transfer import CertificateTransferProvides  # noqa: E501 W505
 
 
-class DummyMutualTLSProviderCharm(CharmBase):
+class DummyCertificateTransferProviderCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
-        self.mutual_tls = MutualTLSProvides(self, "certificates")
+        self.certificate_transfer = CertificateTransferProvides(self, "certificates")
         self.framework.observe(
             self.on.certificates_relation_joined, self._on_certificates_relation_joined
         )
@@ -38,11 +36,11 @@ class DummyMutualTLSProviderCharm(CharmBase):
         certificate = "my certificate"
         ca = "my CA certificate"
         chain = ["certificate 1", "certificate 2"]
-        self.mutual_tls.set_certificate(certificate=certificate, ca=ca, chain=chain)
+        self.certificate_transfer.set_certificate(certificate=certificate, ca=ca, chain=chain)
 
 
 if __name__ == "__main__":
-    main(DummyMutualTLSProviderCharm)
+    main(DummyCertificateTransferProviderCharm)
 ```
 
 ### Requirer charm
@@ -54,18 +52,18 @@ Example:
 from ops.charm import CharmBase
 from ops.main import main
 
-from lib.charms.mutual_tls_interface.v0.mutual_tls import (
+from lib.charms.certificate_transfer_interface.v0.certificate_transfer import (
     CertificateAvailableEvent,
-    MutualTLSRequires,
+    CertificateTransferRequires,
 )
 
 
-class DummyMutualTLSRequirerCharm(CharmBase):
+class DummyCertificateTransferRequirerCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
-        self.mutual_tls = MutualTLSRequires(self, "certificates")
+        self.certificate_transfer = CertificateTransferRequires(self, "certificates")
         self.framework.observe(
-            self.mutual_tls.on.certificate_available, self._on_certificate_available
+            self.certificate_transfer.on.certificate_available, self._on_certificate_available
         )
 
     def _on_certificate_available(self, event: CertificateAvailableEvent):
@@ -75,13 +73,13 @@ class DummyMutualTLSRequirerCharm(CharmBase):
 
 
 if __name__ == "__main__":
-    main(DummyMutualTLSRequirerCharm)
+    main(DummyCertificateTransferRequirerCharm)
 ```
 
 You can relate both charms by running:
 
 ```bash
-juju relate <mutual-tls provider charm> <mutual-tls requirer charm>
+juju relate <certificate_transfer provider charm> <certificate_transfer requirer charm>
 ```
 
 """
@@ -96,7 +94,7 @@ from ops.charm import CharmBase, CharmEvents, RelationChangedEvent
 from ops.framework import EventBase, EventSource, Handle, Object
 
 # The unique Charmhub library identifier, never change it
-LIBID = "b24dab3c7b464669a7710806defe34d4"
+LIBID = "3785165b24a743f2b0c60de52db25c8b"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
@@ -105,16 +103,18 @@ LIBAPI = 0
 # to 0 if you are raising the major API version
 LIBPATCH = 1
 
+PYDEPS = ["jsonschema"]
+
 
 logger = logging.getLogger(__name__)
 
 
 PROVIDER_JSON_SCHEMA = {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/mutual_tls/schemas/provider.json",  # noqa: E501
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/certificate_transfer/schemas/provider.json",  # noqa: E501
     "type": "object",
-    "title": "`mutual_tls` provider schema",
-    "description": "The `mutual_tls` root schema comprises the entire provider application databag for this interface.",  # noqa: E501
+    "title": "`certificate_transfer` provider schema",
+    "description": "The `certificate_transfer` root schema comprises the entire provider application databag for this interface.",  # noqa: E501
     "default": {},
     "examples": [
         {
@@ -200,14 +200,14 @@ def _load_relation_data(raw_relation_data: dict) -> dict:
     return loaded_relation_data
 
 
-class MutualTLSRequirerCharmEvents(CharmEvents):
-    """List of events that the Mutual TLS requirer charm can leverage."""
+class CertificateTransferRequirerCharmEvents(CharmEvents):
+    """List of events that the Certificate Transfer requirer charm can leverage."""
 
     certificate_available = EventSource(CertificateAvailableEvent)
 
 
-class MutualTLSProvides(Object):
-    """Mutual TLS provider class."""
+class CertificateTransferProvides(Object):
+    """Certificate Transfer provider class."""
 
     def __init__(self, charm: CharmBase, relationship_name: str):
         super().__init__(charm, relationship_name)
@@ -281,10 +281,10 @@ class MutualTLSProvides(Object):
             logger.warning("Can't remove certificate - No certificate in relation data")
 
 
-class MutualTLSRequires(Object):
+class CertificateTransferRequires(Object):
     """TLS certificates requirer class to be instantiated by TLS certificates requirers."""
 
-    on = MutualTLSRequirerCharmEvents()
+    on = CertificateTransferRequirerCharmEvents()
 
     def __init__(
         self,

--- a/lib/charms/mutual_tls_interface/v0/mutual_tls.py
+++ b/lib/charms/mutual_tls_interface/v0/mutual_tls.py
@@ -1,0 +1,346 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for the mutual-tls relation.
+
+This library contains the Requires and Provides classes for handling the mutual-tls interface.
+
+## Getting Started
+From a charm directory, fetch the library using `charmcraft`:
+
+```shell
+charmcraft fetch-lib charms.mutual_tls_interface.v0.mutual_tls
+```
+
+Add the following libraries to the charm's `requirements.txt` file:
+- jsonschema
+
+### Provider charm
+The provider charm is the charm providing public certificates to another charm that requires them.
+
+Example:
+```python
+from ops.charm import CharmBase, RelationJoinedEvent
+from ops.main import main
+
+from lib.charms.mutual_tls_interface.v0.mutual_tls import MutualTLSProvides
+
+
+class DummyMutualTLSProviderCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.mutual_tls = MutualTLSProvides(self, "certificates")
+        self.framework.observe(
+            self.on.certificates_relation_joined, self._on_certificates_relation_joined
+        )
+
+    def _on_certificates_relation_joined(self, event: RelationJoinedEvent):
+        certificate = "my certificate"
+        ca = "my CA certificate"
+        chain = ["certificate 1", "certificate 2"]
+        self.mutual_tls.set_certificate(certificate=certificate, ca=ca, chain=chain)
+
+
+if __name__ == "__main__":
+    main(DummyMutualTLSProviderCharm)
+```
+
+### Requirer charm
+The requirer charm is the charm requiring certificates from another charm that provides them.
+
+Example:
+```python
+
+from ops.charm import CharmBase
+from ops.main import main
+
+from lib.charms.mutual_tls_interface.v0.mutual_tls import (
+    CertificateAvailableEvent,
+    MutualTLSRequires,
+)
+
+
+class DummyMutualTLSRequirerCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.mutual_tls = MutualTLSRequires(self, "certificates")
+        self.framework.observe(
+            self.mutual_tls.on.certificate_available, self._on_certificate_available
+        )
+
+    def _on_certificate_available(self, event: CertificateAvailableEvent):
+        print(event.certificate)
+        print(event.ca)
+        print(event.chain)
+
+
+if __name__ == "__main__":
+    main(DummyMutualTLSRequirerCharm)
+```
+
+You can relate both charms by running:
+
+```bash
+juju relate <mutual-tls provider charm> <mutual-tls requirer charm>
+```
+
+"""
+
+
+import json
+import logging
+from typing import List, Optional
+
+from jsonschema import exceptions, validate  # type: ignore[import]
+from ops.charm import CharmBase, CharmEvents, RelationChangedEvent
+from ops.framework import EventBase, EventSource, Handle, Object
+
+# The unique Charmhub library identifier, never change it
+LIBID = "b24dab3c7b464669a7710806defe34d4"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
+logger = logging.getLogger(__name__)
+
+
+PROVIDER_JSON_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/mutual_tls/schemas/provider.json",  # noqa: E501
+    "type": "object",
+    "title": "`mutual_tls` provider schema",
+    "description": "The `mutual_tls` root schema comprises the entire provider application databag for this interface.",  # noqa: E501
+    "default": {},
+    "examples": [
+        {
+            "certificate": "-----BEGIN CERTIFICATE-----\nMIIC6DCCAdCgAwIBAgIUW42TU9LSjEZLMCclWrvSwAsgRtcwDQYJKoZIhvcNAQEL\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIzMDMyNDE4\nNDMxOVoXDTI0MDMyMzE4NDMxOVowPDELMAkGA1UEAwwCb2sxLTArBgNVBC0MJGUw\nNjVmMWI3LTE2OWEtNDE5YS1iNmQyLTc3OWJkOGM4NzIwNjCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBAK42ixoklDH5K5i1NxXo/AFACDa956pE5RA57wlC\nBfgUYaIDRmv7TUVJh6zoMZSD6wjSZl3QgP7UTTZeHbvs3QE9HUwEkH1Lo3a8vD3z\neqsE2vSnOkpWWnPbfxiQyrTm77/LAWBt7lRLRLdfL6WcucD3wsGqm58sWXM3HG0f\nSN7PHCZUFqU6MpkHw8DiKmht5hBgWG+Vq3Zw8MNaqpwb/NgST3yYdcZwb58G2FTS\nZvDSdUfRmD/mY7TpciYV8EFylXNNFkth8oGNLunR9adgZ+9IunfRKj1a7S5GSwXU\nAZDaojw+8k5i3ikztsWH11wAVCiLj/3euIqq95z8xGycnKcCAwEAATANBgkqhkiG\n9w0BAQsFAAOCAQEAWMvcaozgBrZ/MAxzTJmp5gZyLxmMNV6iT9dcqbwzDtDtBvA/\n46ux6ytAQ+A7Bd3AubvozwCr1Id6g66ae0blWYRRZmF8fDdX/SBjIUkv7u9A3NVQ\nXN9gsEvK9pdpfN4ZiflfGSLdhM1STHycLmhG6H5s7HklbukMRhQi+ejbSzm/wiw1\nipcxuKhSUIVNkTLusN5b+HE2gwF1fn0K0z5jWABy08huLgbaEKXJEx5/FKLZGJga\nfpIzAdf25kMTu3gggseaAmzyX3AtT1i8A8nqYfe8fnnVMkvud89kq5jErv/hlMC9\n49g5yWQR2jilYYM3j9BHDuB+Rs+YS5BCep1JnQ==\n-----END CERTIFICATE-----\n",  # noqa: E501
+            "ca": "-----BEGIN CERTIFICATE-----\nMIIC6DCCAdCgAwIBAgIUdiBwE/CtaBXJl3MArjZen6Y8kigwDQYJKoZIhvcNAQEL\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIzMDMyNDE4\nNDg1OVoXDTI0MDMyMzE4NDg1OVowPDELMAkGA1UEAwwCb2sxLTArBgNVBC0MJDEw\nMDdjNDBhLWUwYzMtNDVlOS05YTAxLTVlYjY0NWQ0ZmEyZDCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBANOnUl6JDlXpLMRr/PxgtfE/E5Yk6E/TkPkPL/Kk\ntUGjEi42XZDg9zn3U6cjTDYu+rfKY2jiitfsduW6DQIkEpz3AvbuCMbbgnFpcjsB\nYysLSMTmuz/AVPrfnea/tQTALcONCSy1VhAjGSr81ZRSMB4khl9StSauZrbkpJ1P\nshqkFSUyAi31mKrnXz0Es/v0Yi0FzAlgWrZ4u1Ld+Bo2Xz7oK4mHf7/93Jc+tEaM\nIqG6ocD0q8bjPp0tlSxftVADNUzWlZfM6fue5EXzOsKqyDrxYOSchfU9dNzKsaBX\nkxbHEeSUPJeYYj7aVPEfAs/tlUGsoXQvwWfRie8grp2BoLECAwEAATANBgkqhkiG\n9w0BAQsFAAOCAQEACZARBpHYH6Gr2a1ka0mCWfBmOZqfDVan9rsI5TCThoylmaXW\nquEiZ2LObI+5faPzxSBhr9TjJlQamsd4ywout7pHKN8ZGqrCMRJ1jJbUfobu1n2k\nUOsY4+jzV1IRBXJzj64fLal4QhUNv341lAer6Vz3cAyRk7CK89b/DEY0x+jVpyZT\n1osx9JtsOmkDTgvdStGzq5kPKWOfjwHkmKQaZXliCgqbhzcCERppp1s/sX6K7nIh\n4lWiEmzUSD3Hngk51KGWlpZszO5KQ4cSZ3HUt/prg+tt0ROC3pY61k+m5dDUa9M8\nRtMI6iTjzSj/UV8DiAx0yeM+bKoy4jGeXmaL3g==\n-----END CERTIFICATE-----\n",  # noqa: E501
+            "chain": [
+                "-----BEGIN CERTIFICATE-----\nMIIC6DCCAdCgAwIBAgIUW42TU9LSjEZLMCclWrvSwAsgRtcwDQYJKoZIhvcNAQEL\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIzMDMyNDE4\nNDMxOVoXDTI0MDMyMzE4NDMxOVowPDELMAkGA1UEAwwCb2sxLTArBgNVBC0MJGUw\nNjVmMWI3LTE2OWEtNDE5YS1iNmQyLTc3OWJkOGM4NzIwNjCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBAK42ixoklDH5K5i1NxXo/AFACDa956pE5RA57wlC\nBfgUYaIDRmv7TUVJh6zoMZSD6wjSZl3QgP7UTTZeHbvs3QE9HUwEkH1Lo3a8vD3z\neqsE2vSnOkpWWnPbfxiQyrTm77/LAWBt7lRLRLdfL6WcucD3wsGqm58sWXM3HG0f\nSN7PHCZUFqU6MpkHw8DiKmht5hBgWG+Vq3Zw8MNaqpwb/NgST3yYdcZwb58G2FTS\nZvDSdUfRmD/mY7TpciYV8EFylXNNFkth8oGNLunR9adgZ+9IunfRKj1a7S5GSwXU\nAZDaojw+8k5i3ikztsWH11wAVCiLj/3euIqq95z8xGycnKcCAwEAATANBgkqhkiG\n9w0BAQsFAAOCAQEAWMvcaozgBrZ/MAxzTJmp5gZyLxmMNV6iT9dcqbwzDtDtBvA/\n46ux6ytAQ+A7Bd3AubvozwCr1Id6g66ae0blWYRRZmF8fDdX/SBjIUkv7u9A3NVQ\nXN9gsEvK9pdpfN4ZiflfGSLdhM1STHycLmhG6H5s7HklbukMRhQi+ejbSzm/wiw1\nipcxuKhSUIVNkTLusN5b+HE2gwF1fn0K0z5jWABy08huLgbaEKXJEx5/FKLZGJga\nfpIzAdf25kMTu3gggseaAmzyX3AtT1i8A8nqYfe8fnnVMkvud89kq5jErv/hlMC9\n49g5yWQR2jilYYM3j9BHDuB+Rs+YS5BCep1JnQ==\n-----END CERTIFICATE-----\n",  # noqa: E501
+                "-----BEGIN CERTIFICATE-----\nMIIC6DCCAdCgAwIBAgIUdiBwE/CtaBXJl3MArjZen6Y8kigwDQYJKoZIhvcNAQEL\nBQAwIDELMAkGA1UEBhMCVVMxETAPBgNVBAMMCHdoYXRldmVyMB4XDTIzMDMyNDE4\nNDg1OVoXDTI0MDMyMzE4NDg1OVowPDELMAkGA1UEAwwCb2sxLTArBgNVBC0MJDEw\nMDdjNDBhLWUwYzMtNDVlOS05YTAxLTVlYjY0NWQ0ZmEyZDCCASIwDQYJKoZIhvcN\nAQEBBQADggEPADCCAQoCggEBANOnUl6JDlXpLMRr/PxgtfE/E5Yk6E/TkPkPL/Kk\ntUGjEi42XZDg9zn3U6cjTDYu+rfKY2jiitfsduW6DQIkEpz3AvbuCMbbgnFpcjsB\nYysLSMTmuz/AVPrfnea/tQTALcONCSy1VhAjGSr81ZRSMB4khl9StSauZrbkpJ1P\nshqkFSUyAi31mKrnXz0Es/v0Yi0FzAlgWrZ4u1Ld+Bo2Xz7oK4mHf7/93Jc+tEaM\nIqG6ocD0q8bjPp0tlSxftVADNUzWlZfM6fue5EXzOsKqyDrxYOSchfU9dNzKsaBX\nkxbHEeSUPJeYYj7aVPEfAs/tlUGsoXQvwWfRie8grp2BoLECAwEAATANBgkqhkiG\n9w0BAQsFAAOCAQEACZARBpHYH6Gr2a1ka0mCWfBmOZqfDVan9rsI5TCThoylmaXW\nquEiZ2LObI+5faPzxSBhr9TjJlQamsd4ywout7pHKN8ZGqrCMRJ1jJbUfobu1n2k\nUOsY4+jzV1IRBXJzj64fLal4QhUNv341lAer6Vz3cAyRk7CK89b/DEY0x+jVpyZT\n1osx9JtsOmkDTgvdStGzq5kPKWOfjwHkmKQaZXliCgqbhzcCERppp1s/sX6K7nIh\n4lWiEmzUSD3Hngk51KGWlpZszO5KQ4cSZ3HUt/prg+tt0ROC3pY61k+m5dDUa9M8\nRtMI6iTjzSj/UV8DiAx0yeM+bKoy4jGeXmaL3g==\n-----END CERTIFICATE-----\n",  # noqa: E501
+            ],
+        }
+    ],
+    "properties": {
+        "certificate": {
+            "$id": "#/properties/certificate",
+            "type": "string",
+            "title": "Public TLS certificate",
+            "description": "Public TLS certificate",
+        },
+        "ca": {
+            "$id": "#/properties/ca",
+            "type": "string",
+            "title": "CA public TLS certificate",
+            "description": "CA Public TLS certificate",
+        },
+        "chain": {
+            "$id": "#/properties/chain",
+            "type": "array",
+            "items": {"type": "string", "$id": "#/properties/chain/items"},
+            "title": "CA public TLS certificate chain",
+            "description": "CA public TLS certificate chain",
+        },
+    },
+    "anyOf": [{"required": ["certificate"]}, {"required": ["ca"]}, {"required": ["chain"]}],
+    "additionalProperties": True,
+}
+
+
+class CertificateAvailableEvent(EventBase):
+    """Charm Event triggered when a TLS certificate is available."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        certificate: str,
+        ca: str,
+        chain: List[str],
+    ):
+        super().__init__(handle)
+        self.certificate = certificate
+        self.ca = ca
+        self.chain = chain
+
+    def snapshot(self) -> dict:
+        """Return snapshot."""
+        return {
+            "certificate": self.certificate,
+            "ca": self.ca,
+            "chain": self.chain,
+        }
+
+    def restore(self, snapshot: dict):
+        """Restores snapshot."""
+        self.certificate = snapshot["certificate"]
+        self.ca = snapshot["ca"]
+        self.chain = snapshot["chain"]
+
+
+def _load_relation_data(raw_relation_data: dict) -> dict:
+    """Load relation data from the relation data bag.
+
+    Args:
+        raw_relation_data: Relation data from the databag
+
+    Returns:
+        dict: Relation data in dict format.
+    """
+    loaded_relation_data = {}
+    for key in raw_relation_data:
+        try:
+            loaded_relation_data[key] = json.loads(raw_relation_data[key])
+        except (json.decoder.JSONDecodeError, TypeError):
+            loaded_relation_data[key] = raw_relation_data[key]
+    return loaded_relation_data
+
+
+class MutualTLSRequirerCharmEvents(CharmEvents):
+    """List of events that the Mutual TLS requirer charm can leverage."""
+
+    certificate_available = EventSource(CertificateAvailableEvent)
+
+
+class MutualTLSProvides(Object):
+    """Mutual TLS provider class."""
+
+    def __init__(self, charm: CharmBase, relationship_name: str):
+        super().__init__(charm, relationship_name)
+        self.charm = charm
+        self.relationship_name = relationship_name
+
+    def set_certificate(
+        self,
+        certificate: str,
+        ca: str,
+        chain: List[str],
+        relation_id: Optional[int] = None,
+    ) -> None:
+        """Add certificates to relation data.
+
+        Args:
+            certificate (str): Certificate
+            ca (str): CA Certificate
+            chain (list): CA Chain
+            relation_id (int): Juju relation ID
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(
+            relation_name=self.relationship_name,
+            relation_id=relation_id,
+        )
+        if not relation:
+            raise RuntimeError(
+                f"No relation found with relation name {self.relationship_name} and "
+                f"relation ID {relation_id}"
+            )
+        relation.data[self.model.unit]["certificate"] = certificate
+        relation.data[self.model.unit]["ca"] = ca
+        relation.data[self.model.unit]["chain"] = json.dumps(chain)
+
+    def remove_certificate(self, relation_id: Optional[int] = None) -> None:
+        """Remove a given certificate from relation data.
+
+        Args:
+            relation_id (int): Relation ID
+
+        Returns:
+            None
+        """
+        relation = self.model.get_relation(
+            relation_name=self.relationship_name,
+            relation_id=relation_id,
+        )
+        if not relation:
+            logger.warning(
+                f"Can't remove certificate - Non-existent relation '{self.relationship_name}'"
+            )
+            return
+        unit_relation_data = relation.data[self.model.unit]
+        certificate_removed = False
+        if "certificate" in unit_relation_data:
+            relation.data[self.model.unit].pop("certificate")
+            certificate_removed = True
+        if "ca" in unit_relation_data:
+            relation.data[self.model.unit].pop("ca")
+            certificate_removed = True
+        if "chain" in unit_relation_data:
+            relation.data[self.model.unit].pop("chain")
+            certificate_removed = True
+
+        if certificate_removed:
+            logger.warning("Certificate removed from relation data")
+        else:
+            logger.warning("Can't remove certificate - No certificate in relation data")
+
+
+class MutualTLSRequires(Object):
+    """TLS certificates requirer class to be instantiated by TLS certificates requirers."""
+
+    on = MutualTLSRequirerCharmEvents()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relationship_name: str,
+    ):
+        """Generates/use private key and observes relation changed event.
+
+        Args:
+            charm: Charm object
+            relationship_name: Juju relation name
+        """
+        super().__init__(charm, relationship_name)
+        self.relationship_name = relationship_name
+        self.charm = charm
+        self.framework.observe(
+            charm.on[relationship_name].relation_changed, self._on_relation_changed
+        )
+
+    @staticmethod
+    def _relation_data_is_valid(relation_data: dict) -> bool:
+        """Return whether relation data is valid based on json schema.
+
+        Args:
+            relation_data: Relation data in dict format.
+
+        Returns:
+            bool: Whether relation data is valid.
+        """
+        try:
+            validate(instance=relation_data, schema=PROVIDER_JSON_SCHEMA)
+            return True
+        except exceptions.ValidationError:
+            return False
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Emit certificate available event.
+
+        Args:
+            event: Juju event
+
+        Returns:
+            None
+        """
+        if not event.unit:
+            logger.info(f"No remote unit in relation: {self.relationship_name}")
+            return
+        remote_unit_relation_data = _load_relation_data(event.relation.data[event.unit])
+        if not self._relation_data_is_valid(remote_unit_relation_data):
+            logger.warning(
+                f"Provider relation data did not pass JSON Schema validation: "
+                f"{event.relation.data[event.unit]}"
+            )
+            return
+        self.on.certificate_available.emit(
+            certificate=remote_unit_relation_data.get("certificate"),
+            ca=remote_unit_relation_data.get("ca"),
+            chain=remote_unit_relation_data.get("chain"),
+        )

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -309,7 +309,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -1391,7 +1391,7 @@ class TLSCertificatesRequiresV2(Object):
                                 ),
                             )
                         except SecretNotFoundError:
-                            secret = self.charm.app.add_secret(
+                            secret = self.charm.unit.add_secret(
                                 {"certificate": certificate["certificate"]},
                                 label=f"{LIBID}-{certificate['certificate_signing_request']}",
                                 expire=self._get_next_secret_expiry_time(

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,11 +10,11 @@ summary: An operator to provide self-signed X.509 certificates to your charms.
 description: |
   An operator to provide self-signed X.509 certificates to your charms.
 
-  This charm relies on the `tls-certificates` charm relation interface. When a requirer charm 
-  inserts a Certificate Signing Request in its unit databag, the 
+  This charm relies on the `tls-certificates` charm relation interface. When a requirer charm
+  inserts a Certificate Signing Request in its unit databag, the
   `self-signed-certificates-operator` will read it, generate a self-signed X.509 certificates and
   inserts this certificate back into the relation data.
-  
+
   This charm is useful when developing charms or when deploying charms in non-production environment.
 
 website: https://charmhub.io/self-signed-certificates
@@ -24,6 +24,11 @@ issues: https://github.com/canonical/self-signed-certificates-operator/issues
 provides:
   certificates:
     interface: tls-certificates
+  send-ca-cert:
+    interface: mutual_tls
+    description: |
+      Send our CA certificate so clients can trust the CA by means of forming a relation.
+      Note: The interface name is a misnomer, as this is not in fact mTLS.
 
 assumes:
   - juju >= 3.1

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -25,10 +25,9 @@ provides:
   certificates:
     interface: tls-certificates
   send-ca-cert:
-    interface: mutual_tls
+    interface: certificate_transfer
     description: |
       Send our CA certificate so clients can trust the CA by means of forming a relation.
-      Note: The interface name is a misnomer, as this is not in fact mTLS.
 
 assumes:
   - juju >= 3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,14 @@ ignore = ["D107"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
 per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
 docstring-convention = "google"
+
+# Static analysis tools configuration
+[tool.mypy]
+pretty = true
+python_version = "3.10"
+mypy_path = "$MYPY_CONFIG_FILE_DIR/lib"
+
+# Ignore libraries that do not have type hint nor stubs
+[[tool.mypy.overrides]]
+module = ["charms.tls_certificates_interface.*"]
+follow_imports = "silent"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ pretty = true
 python_version = "3.10"
 mypy_path = "$MYPY_CONFIG_FILE_DIR/lib"
 
-# Ignore libraries that do not have type hint nor stubs
+# Ignore 3rd party libraries that have typing issues
 [[tool.mypy.overrides]]
 module = ["charms.tls_certificates_interface.*"]
 follow_imports = "silent"

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,7 +9,9 @@ import logging
 import secrets
 from typing import Optional
 
-from charms.mutual_tls_interface.v0.mutual_tls import MutualTLSProvides
+from charms.certificate_transfer_interface.v0.certificate_transfer import (
+    CertificateTransferProvides,
+)
 from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ignore[import]
     CertificateCreationRequestEvent,
     TLSCertificatesProvidesV2,
@@ -222,7 +224,7 @@ class SelfSignedCertificatesCharm(CharmBase):
         Args:
             rel_id: Relation id. If not given, update all relations.
         """
-        send_ca_cert = MutualTLSProvides(self, SEND_CA_CERT_REL_NAME)
+        send_ca_cert = CertificateTransferProvides(self, SEND_CA_CERT_REL_NAME)
         if self._root_certificate_is_stored:
             secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
             secret_content = secret.get_content()

--- a/src/charm.py
+++ b/src/charm.py
@@ -214,7 +214,6 @@ class SelfSignedCertificatesCharm(CharmBase):
         logger.info(f"Generated certificate for relation {event.relation_id}")
 
     def _on_send_ca_cert_relation_joined(self, event: RelationJoinedEvent):
-        # TODO modify func to also work with deltas (take an event arg)
         self._send_ca_cert(rel_id=event.relation.id)
 
     def _send_ca_cert(self, *, rel_id=None):

--- a/src/charm.py
+++ b/src/charm.py
@@ -45,7 +45,7 @@ class SelfSignedCertificatesCharm(CharmBase):
             self.on.get_issued_certificates_action, self._on_get_issued_certificates
         )
         self.framework.observe(
-            self.on.send_ca_cert_relation_joined,  # pyright: ignore
+            self.on[SEND_CA_CERT_REL_NAME].relation_joined,
             self._on_send_ca_cert_relation_joined,
         )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,6 +9,7 @@ import logging
 import secrets
 from typing import Optional
 
+from charms.mutual_tls_interface.v0.mutual_tls import MutualTLSProvides
 from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ignore[import]
     CertificateCreationRequestEvent,
     TLSCertificatesProvidesV2,
@@ -16,7 +17,7 @@ from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ign
     generate_certificate,
     generate_private_key,
 )
-from ops.charm import ActionEvent, CharmBase, EventBase
+from ops.charm import ActionEvent, CharmBase, EventBase, RelationJoinedEvent
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, SecretNotFoundError, WaitingStatus
 
@@ -24,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 CA_CERTIFICATES_SECRET_LABEL = "ca-certificates"
+SEND_CA_CERT_REL_NAME = "send-ca-cert"  # Must match metadata
 
 
 class SelfSignedCertificatesCharm(CharmBase):
@@ -39,6 +41,13 @@ class SelfSignedCertificatesCharm(CharmBase):
             self._on_certificate_creation_request,
         )
         self.framework.observe(self.on.secret_expired, self._configure_ca)
+        self.framework.observe(
+            self.on.get_issued_certificates_action, self._on_get_issued_certificates
+        )
+        self.framework.observe(
+            self.on.send_ca_cert_relation_joined,  # pyright: ignore
+            self._on_send_ca_cert_relation_joined,
+        )
 
     @property
     def _config_root_ca_certificate_validity(self) -> int:
@@ -48,10 +57,6 @@ class SelfSignedCertificatesCharm(CharmBase):
             int: Certificate validity (in days)
         """
         return int(self.model.config.get("root-ca-validity"))  # type: ignore[arg-type]
-
-        self.framework.observe(
-            self.on.get_issued_certificates_action, self._on_get_issued_certificates
-        )
 
     def _on_get_issued_certificates(self, event: ActionEvent) -> None:
         """Handler for the get-issued-certificates action.
@@ -154,6 +159,7 @@ class SelfSignedCertificatesCharm(CharmBase):
         self._generate_root_certificate()
         self.tls_certificates.revoke_all_certificates()
         logger.info("Revoked all previously issued certificates.")
+        self._send_ca_cert()
         self.unit.status = ActiveStatus()
 
     def _invalid_configs(self) -> list[str]:
@@ -206,6 +212,30 @@ class SelfSignedCertificatesCharm(CharmBase):
             relation_id=event.relation_id,
         )
         logger.info(f"Generated certificate for relation {event.relation_id}")
+
+    def _on_send_ca_cert_relation_joined(self, event: RelationJoinedEvent):
+        # TODO modify func to also work with deltas (take an event arg)
+        self._send_ca_cert(rel_id=event.relation.id)
+
+    def _send_ca_cert(self, *, rel_id=None):
+        """There is one (and only one) CA cert that we need to forward to multiple apps.
+
+        Args:
+            rel_id: Relation id. If not given, update all relations.
+        """
+        send_ca_cert = MutualTLSProvides(self, SEND_CA_CERT_REL_NAME)
+        if self._root_certificate_is_stored:
+            secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
+            secret_content = secret.get_content()
+            ca = secret_content["ca-certificate"]
+            if rel_id:
+                send_ca_cert.set_certificate("", ca, [], relation_id=rel_id)
+            else:
+                for relation in self.model.relations.get(SEND_CA_CERT_REL_NAME, []):
+                    send_ca_cert.set_certificate("", ca, [], relation_id=relation.id)
+        else:
+            for relation in self.model.relations.get(SEND_CA_CERT_REL_NAME, []):
+                send_ca_cert.remove_certificate(relation.id)
 
 
 def generate_password() -> str:

--- a/tests/unit/test_send_ca_cert.py
+++ b/tests/unit/test_send_ca_cert.py
@@ -20,9 +20,11 @@ class TestSendCaCert(unittest.TestCase):
         self.rel_id = self.harness.add_relation(relation_name="send-ca-cert", remote_app="traefik")
         self.harness.add_relation_unit(relation_id=self.rel_id, remote_unit_name="traefik/0")
         data = self.harness.get_relation_data(self.rel_id, self.harness.charm.unit)
+        ca_from_rel_data = data["ca"]
 
-        ca = self.harness.charm.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL).get_content()[
-            "ca-certificate"
-        ]
+        secret = self.harness.charm.model.get_secret(
+            label=CA_CERTIFICATES_SECRET_LABEL
+        ).get_content()
+        ca_from_secret = secret["ca-certificate"]
 
-        self.assertEqual(ca, data["ca"])
+        self.assertEqual(ca_from_secret, ca_from_rel_data)

--- a/tests/unit/test_send_ca_cert.py
+++ b/tests/unit/test_send_ca_cert.py
@@ -1,0 +1,28 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import unittest
+
+import ops
+import ops.testing
+
+from charm import CA_CERTIFICATES_SECRET_LABEL, SelfSignedCertificatesCharm
+
+
+class TestSendCaCert(unittest.TestCase):
+    def setUp(self):
+        self.harness = ops.testing.Harness(SelfSignedCertificatesCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.set_leader(is_leader=True)
+        self.harness.begin_with_initial_hooks()
+
+    def test_when_relation_joins_then_ca_cert_is_advertised(self):
+        self.rel_id = self.harness.add_relation(relation_name="send-ca-cert", remote_app="traefik")
+        self.harness.add_relation_unit(relation_id=self.rel_id, remote_unit_name="traefik/0")
+        data = self.harness.get_relation_data(self.rel_id, self.harness.charm.unit)
+
+        ca = self.harness.charm.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL).get_content()[
+            "ca-certificate"
+        ]
+
+        self.assertEqual(ca, data["ca"])

--- a/tests/unit/test_send_ca_cert.py
+++ b/tests/unit/test_send_ca_cert.py
@@ -16,10 +16,12 @@ class TestSendCaCert(unittest.TestCase):
         self.harness.set_leader(is_leader=True)
         self.harness.begin_with_initial_hooks()
 
-    def test_when_relations_joins_then_ca_cert_is_advertised(self):
+    def test_when_relation_join_then_ca_cert_is_advertised(self):
         # Add a few apps
         apps = ["traefik", "another"]
-        rel_ids = [self.harness.add_relation(relation_name="send-ca-cert", remote_app=app) for app in apps]
+        rel_ids = [
+            self.harness.add_relation(relation_name="send-ca-cert", remote_app=app) for app in apps
+        ]
         for app, rel_id in zip(apps, rel_ids):
             self.harness.add_relation_unit(relation_id=rel_id, remote_unit_name=f"{app}/0")
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,9 @@ skip_missing_interpreters = True
 envlist = lint, unit, static
 
 [vars]
-src_path = {toxinidir}/src/
-unit_test_path = {toxinidir}/tests/unit/
-integration_test_path = {toxinidir}/tests/integration/
+src_path = {toxinidir}/src
+unit_test_path = {toxinidir}/tests/unit
+integration_test_path = {toxinidir}/tests/integration
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
@@ -43,7 +43,7 @@ description = Run static analysis checks
 setenv =
     PYTHONPATH = ""
 commands =
-    mypy {[vars]all_path} {posargs}
+    mypy {[vars]src_path} {posargs}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
# Description
This PR adds a `mtls` relation for forwarding the ca cert.
Fixes #21.

This way, traefik won't need to send a CSR to the local-ca in order to obtain the ca cert (traefik needs the ca cert to load-balance https endpoints):

```mermaid
graph LR

external-ca ---|tls-certificates| traefik
subgraph your-model
  traefik ---|ingress| your-app
  your-app ---|tls-certificates| local-ca
  traefik ---|send-ca-cert| local-ca
end
```
([Edit a copy of this diagram](https://mermaid.live/edit#pako:eNp1kLFqAzEMhl_l0Hx-gZvbLV3arWhRbV1iasvGliEhybvHcbhSAtmE9H2_kM5gk2NYYF8oH6bdJwoKH5WLUDCWJmPMRUM1lov61VtSrpdJC_Hqf1Fq-3mYp9SKiT0roEzbfNhe9oVrlwZCOd-BrX6RH5Id65-zKovr7UH_p3obBWaIXCJ51-8531UEPXBkhKWXjldqQRFQrh1t2fVd785rKrCsFCrPQE3T10ksLFoab9Cbp35k_KN4SB-Px43_zZBJvlPamOsNL3x6JA))

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
