### PR TITLE
FIX: get-issued-certificates

### DIFF
--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -1071,7 +1071,7 @@ class TLSCertificatesProvidesV2(Object):
         Returns:
             dict: Certificates per application name.
         """
-        certificates: Dict[str, Dict[str, str]] = defaultdict(dict)
+        certificates: Dict[str, str] = defaultdict(str)
         relations = (
             [self.model.relations[self.relationship_name][relation_id]]
             if relation_id
@@ -1081,9 +1081,8 @@ class TLSCertificatesProvidesV2(Object):
             provider_relation_data = _load_relation_data(relation.data[self.charm.app])
             provider_certificates = provider_relation_data.get("certificates", [])
             for certificate in provider_certificates:
-                certificates[relation.app.name].update(  # type: ignore[union-attr]
-                    {certificate["certificate_signing_request"]: certificate["certificate"]}
-                )
+                certificates[relation.app.name] = f"CSR: \n{certificate['certificate_signing_request']}\nCERT: \n{certificate['certificate']}"
+
         return certificates
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -1060,7 +1060,9 @@ class TLSCertificatesProvidesV2(Object):
         for certificate_relation in certificates_relation:
             self._remove_certificate(certificate=certificate, relation_id=certificate_relation.id)
 
-    def get_issued_certificates(self, relation_id: Optional[int] = None) -> Dict[str, str]:
+    def get_issued_certificates(
+        self, relation_id: Optional[int] = None
+    ) -> Dict[str, list[Dict[str, str]]]:
         """Returns a dictionary of issued certificates.
 
         It returns certificates from all relations if relation_id is not specified.
@@ -1069,7 +1071,7 @@ class TLSCertificatesProvidesV2(Object):
         Returns:
             dict: Certificates per application name.
         """
-        certificates: Dict[str, list] = defaultdict(list)
+        certificates: Dict[str, list[Dict[str, str]]] = defaultdict(list)
         relations = (
             [self.model.relations[self.relationship_name][relation_id]]
             if relation_id

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -1086,7 +1086,7 @@ class TLSCertificatesProvidesV2(Object):
                     }
                 )
 
-        return {key: json.dumps(value) for key, value in certificates.items()}
+        return certificates
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
         """Handler triggered on relation changed event.

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -1060,9 +1060,7 @@ class TLSCertificatesProvidesV2(Object):
         for certificate_relation in certificates_relation:
             self._remove_certificate(certificate=certificate, relation_id=certificate_relation.id)
 
-    def get_issued_certificates(
-        self, relation_id: Optional[int] = None
-    ) -> Dict[str, Dict[str, str]]:
+    def get_issued_certificates(self, relation_id: Optional[int] = None) -> Dict[str, str]:
         """Returns a dictionary of issued certificates.
 
         It returns certificates from all relations if relation_id is not specified.
@@ -1071,7 +1069,7 @@ class TLSCertificatesProvidesV2(Object):
         Returns:
             dict: Certificates per application name.
         """
-        certificates: Dict[str, str] = defaultdict(str)
+        certificates: Dict[str, list] = defaultdict(list)
         relations = (
             [self.model.relations[self.relationship_name][relation_id]]
             if relation_id
@@ -1081,9 +1079,14 @@ class TLSCertificatesProvidesV2(Object):
             provider_relation_data = _load_relation_data(relation.data[self.charm.app])
             provider_certificates = provider_relation_data.get("certificates", [])
             for certificate in provider_certificates:
-                certificates[relation.app.name] = f"CSR: \n{certificate['certificate_signing_request']}\nCERT: \n{certificate['certificate']}"
+                certificates[relation.app.name].append(
+                    {
+                        "csr": certificate["certificate_signing_request"],
+                        "certificate": certificate["certificate"],
+                    }
+                )
 
-        return certificates
+        return {key: json.dumps(value) for key, value in certificates.items()}
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
         """Handler triggered on relation changed event.

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -276,11 +276,10 @@ import copy
 import json
 import logging
 import uuid
-from collections import defaultdict
 from contextlib import suppress
 from datetime import datetime, timedelta
 from ipaddress import IPv4Address
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from cryptography import x509
 from cryptography.hazmat._oid import ExtensionOID
@@ -309,7 +308,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 11
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -1062,7 +1061,7 @@ class TLSCertificatesProvidesV2(Object):
 
     def get_issued_certificates(
         self, relation_id: Optional[int] = None
-    ) -> Dict[str, list[Dict[str, str]]]:
+    ) -> Dict[str, List[Dict[str, str]]]:
         """Returns a dictionary of issued certificates.
 
         It returns certificates from all relations if relation_id is not specified.
@@ -1071,22 +1070,29 @@ class TLSCertificatesProvidesV2(Object):
         Returns:
             dict: Certificates per application name.
         """
-        certificates: Dict[str, list[Dict[str, str]]] = defaultdict(list)
+        certificates: Dict[str, List[Dict[str, str]]] = {}
         relations = (
-            [self.model.relations[self.relationship_name][relation_id]]
-            if relation_id
+            [
+                relation
+                for relation in self.model.relations[self.relationship_name]
+                if relation.id == relation_id
+            ]
+            if relation_id is not None
             else self.model.relations.get(self.relationship_name, [])
         )
         for relation in relations:
             provider_relation_data = _load_relation_data(relation.data[self.charm.app])
             provider_certificates = provider_relation_data.get("certificates", [])
+
+            certificates[relation.app.name] = []  # type: ignore[union-attr]
             for certificate in provider_certificates:
-                certificates[relation.app.name].append(
-                    {
-                        "csr": certificate["certificate_signing_request"],
-                        "certificate": certificate["certificate"],
-                    }
-                )
+                if not certificate.get("revoked", False):
+                    certificates[relation.app.name].append(  # type: ignore[union-attr]
+                        {
+                            "csr": certificate["certificate_signing_request"],
+                            "certificate": certificate["certificate"],
+                        }
+                    )
 
         return certificates
 
@@ -1163,6 +1169,84 @@ class TLSCertificatesProvidesV2(Object):
                 )
                 self.remove_certificate(certificate=certificate["certificate"])
 
+    def get_requirer_csrs_with_no_certs(
+        self,
+    ) -> List[Dict[str, Union[int, str, List[Dict[str, str]]]]]:
+        """Filters the requirer's units csrs.
+
+        Keeps the ones for which no certificate was provided.
+
+        Returns:
+            list: List of dictionaries that contain the unit's csrs
+            that don't have a certificate issued.
+        """
+        all_unit_csr_mappings = copy.deepcopy(self.get_requirer_csrs())
+        for unit_csr_mapping in all_unit_csr_mappings:
+            for csr in unit_csr_mapping["unit_csrs"]:  # type: ignore[union-attr]
+                if self.certificate_issued_for_csr(
+                    app_name=unit_csr_mapping["application_name"],  # type: ignore[arg-type]
+                    csr=csr["certificate_signing_request"],  # type: ignore[index]
+                ):
+                    unit_csr_mapping["unit_csrs"].remove(csr)  # type: ignore[union-attr, arg-type]
+            if len(unit_csr_mapping["unit_csrs"]) == 0:  # type: ignore[arg-type]
+                all_unit_csr_mappings.remove(unit_csr_mapping)
+        return all_unit_csr_mappings
+
+    def get_requirer_csrs(
+        self, relation_id: Optional[int] = None
+    ) -> List[Dict[str, Union[int, str, List[Dict[str, str]]]]]:
+        """Returns a list of requirers' CSRs grouped by unit.
+
+        It returns CSRs from all relations if relation_id is not specified.
+        CSRs are returned per relation id, application name and unit name.
+
+        Returns:
+            list: List of dictionaries that contain the unit's csrs
+            with the following information
+            relation_id, application_name and unit_name.
+        """
+        unit_csr_mappings: List[Dict[str, Union[int, str, List[Dict[str, str]]]]] = []
+
+        relations = (
+            [
+                relation
+                for relation in self.model.relations[self.relationship_name]
+                if relation.id == relation_id
+            ]
+            if relation_id is not None
+            else self.model.relations.get(self.relationship_name, [])
+        )
+
+        for relation in relations:
+            for unit in relation.units:
+                requirer_relation_data = _load_relation_data(relation.data[unit])
+                unit_csrs_list = requirer_relation_data.get("certificate_signing_requests", [])
+                unit_csr_mappings.append(
+                    {
+                        "relation_id": relation.id,
+                        "application_name": relation.app.name,  # type: ignore[union-attr]
+                        "unit_name": unit.name,
+                        "unit_csrs": unit_csrs_list,
+                    }
+                )
+        return unit_csr_mappings
+
+    def certificate_issued_for_csr(self, app_name: str, csr: str) -> bool:
+        """Checks whether a certificate has been issued for a given CSR.
+
+        Args:
+            app_name (str): Application name that the CSR belongs to.
+            csr (str): Certificate Signing Request.
+
+        Returns:
+            bool: True/False depending on whether a certificate has been issued for the given CSR.
+        """
+        issued_certificates_per_csr = self.get_issued_certificates()[app_name]
+        for issued_pair in issued_certificates_per_csr:
+            if "csr" in issued_pair and issued_pair["csr"] == csr:
+                return csr_matches_certificate(csr, issued_pair["certificate"])
+        return False
+
 
 class TLSCertificatesRequiresV2(Object):
     """TLS certificates requirer class to be instantiated by TLS certificates requirers."""
@@ -1200,7 +1284,7 @@ class TLSCertificatesRequiresV2(Object):
 
     @property
     def _requirer_csrs(self) -> List[Dict[str, str]]:
-        """Returns list of requirer CSR's from relation data."""
+        """Returns list of requirer's CSRs from relation data."""
         relation = self.model.get_relation(self.relationship_name)
         if not relation:
             raise RuntimeError(f"Relation {self.relationship_name} does not exist")
@@ -1538,6 +1622,37 @@ class TLSCertificatesRequiresV2(Object):
                     certificate=certificate_dict["certificate"],
                     expiry=expiry_time.isoformat(),
                 )
+
+
+def csr_matches_certificate(csr: str, cert: str) -> bool:
+    """Check if a CSR matches a certificate.
+
+    expects to get the original string representations.
+
+    Args:
+        csr (str): Certificate Signing Request
+        cert (str): Certificate
+    Returns:
+        bool: True/False depending on whether the CSR matches the certificate.
+    """
+    try:
+        csr_object = x509.load_pem_x509_csr(csr.encode("utf-8"))
+        cert_object = x509.load_pem_x509_certificate(cert.encode("utf-8"))
+
+        if csr_object.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ) != cert_object.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ):
+            return False
+        if csr_object.subject != cert_object.subject:
+            return False
+    except ValueError:
+        logger.warning("Could not load certificate or CSR.")
+        return False
+    return True
 
 
 def _get_closest_future_time(

--- a/src/charm.py
+++ b/src/charm.py
@@ -75,7 +75,7 @@ class SelfSignedCertificatesCharm(CharmBase):
         if not certificates:
             event.fail("No certificates issued yet.")
             return
-        event.set_results({"issued_certificates": certificates})
+        event.set_results(certificates)
 
     @property
     def _config_certificate_validity(self) -> int:

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,6 +6,7 @@
 
 import datetime
 import logging
+import json
 import secrets
 from typing import Optional
 
@@ -75,7 +76,7 @@ class SelfSignedCertificatesCharm(CharmBase):
         if not certificates:
             event.fail("No certificates issued yet.")
             return
-        event.set_results(certificates)
+        event.set_results({key: json.dumps(value) for key, value in certificates.items()})
 
     @property
     def _config_certificate_validity(self) -> int:

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,8 +5,8 @@
 """Self Signed X.509 Certificates."""
 
 import datetime
-import logging
 import json
+import logging
 import secrets
 from typing import Optional
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -286,9 +286,8 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._on_get_issued_certificates(action_event)
 
         expected_certificates = {
-            "tls-requirer": {
-                "whatever csr": "whatever cert",
-            }
+            "tls-requirer": "CSR: \nwhatever csr\nCERT: \nwhatever cert",
+            
         }
 
-        action_event.set_results.assert_called_with({"issued_certificates": expected_certificates})
+        action_event.set_results.assert_called_with(expected_certificates)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -287,7 +287,6 @@ class TestCharm(unittest.TestCase):
 
         expected_certificates = {
             "tls-requirer": "CSR: \nwhatever csr\nCERT: \nwhatever cert",
-            
         }
 
         action_event.set_results.assert_called_with(expected_certificates)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -286,7 +286,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._on_get_issued_certificates(action_event)
 
         expected_certificates = {
-            "tls-requirer": "CSR: \nwhatever csr\nCERT: \nwhatever cert",
+            "tls-requirer": '[{"csr": "whatever csr", "certificate": "whatever cert"}]',
         }
 
         action_event.set_results.assert_called_with(expected_certificates)


### PR DESCRIPTION
# Description

This fixes the bug with the action `get-issued-certificates`. The problem occurred when setting the results of the event, the expected data structure was a Dict[str, str], but the given was a nested dict. This PR converts the nested dicts into a formatted string.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
