### PR TITLE
Update tls_certificates_interface lib to fix permission deny error during scale operation

### DIFF
--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -298,7 +298,7 @@ from ops.charm import (
 )
 from ops.framework import EventBase, EventSource, Handle, Object
 from ops.jujuversion import JujuVersion
-from ops.model import SecretNotFoundError
+from ops.model import Relation, SecretNotFoundError
 
 # The unique Charmhub library identifier, never change it
 LIBID = "afd8c2bccf834997afce12c2706d2ede"
@@ -897,21 +897,21 @@ class TLSCertificatesProvidesV2(Object):
         self.charm = charm
         self.relationship_name = relationship_name
 
-    def _load_relation_data(self, raw_relation_data: dict) -> dict:
-        """Loads relation data from the relation data bag.
+    def _load_app_relation_data(self, relation: Relation) -> dict:
+        """Loads relation data from the application relation data bag.
 
         Json loads all data.
 
         Args:
-            raw_relation_data (dict): Relation data from the databag
+            relation_object: Relation data from the application databag
 
         Returns:
-            dict: Relation data in dict
+            dict: Relation data in dict format.
         """
         # If unit is not leader, it does not try to reach relation data.
         if not self.model.unit.is_leader():
             return {}
-        return _load_relation_data(raw_relation_data)
+        return _load_relation_data(relation.data[self.charm.app])
 
     def _add_certificate(
         self,
@@ -947,7 +947,7 @@ class TLSCertificatesProvidesV2(Object):
             "ca": ca,
             "chain": chain,
         }
-        provider_relation_data = self._load_relation_data(relation.data[self.charm.app])
+        provider_relation_data = self._load_app_relation_data(relation)
         provider_certificates = provider_relation_data.get("certificates", [])
         certificates = copy.deepcopy(provider_certificates)
         if new_certificate in certificates:
@@ -980,7 +980,7 @@ class TLSCertificatesProvidesV2(Object):
             raise RuntimeError(
                 f"Relation {self.relationship_name} with relation id {relation_id} does not exist"
             )
-        provider_relation_data = self._load_relation_data(relation.data[self.charm.app])
+        provider_relation_data = self._load_app_relation_data(relation)
         provider_certificates = provider_relation_data.get("certificates", [])
         certificates = copy.deepcopy(provider_certificates)
         for certificate_dict in certificates:
@@ -1015,7 +1015,7 @@ class TLSCertificatesProvidesV2(Object):
         This method is meant to be used when the Root CA has changed.
         """
         for relation in self.model.relations[self.relationship_name]:
-            provider_relation_data = self._load_relation_data(relation.data[self.charm.app])
+            provider_relation_data = self._load_app_relation_data(relation)
             provider_certificates = copy.deepcopy(provider_relation_data.get("certificates", []))
             for certificate in provider_certificates:
                 certificate["revoked"] = True
@@ -1097,7 +1097,7 @@ class TLSCertificatesProvidesV2(Object):
             else self.model.relations.get(self.relationship_name, [])
         )
         for relation in relations:
-            provider_relation_data = self._load_relation_data(relation.data[self.charm.app])
+            provider_relation_data = self._load_app_relation_data(relation)
             provider_certificates = provider_relation_data.get("certificates", [])
 
             certificates[relation.app.name] = []  # type: ignore[union-attr]
@@ -1129,8 +1129,10 @@ class TLSCertificatesProvidesV2(Object):
         """
         if event.unit is None:
             return
+        if not self.model.unit.is_leader():
+            return
         requirer_relation_data = _load_relation_data(event.relation.data[event.unit])
-        provider_relation_data = self._load_relation_data(event.relation.data[self.charm.app])
+        provider_relation_data = self._load_app_relation_data(event.relation)
         if not self._relation_data_is_valid(requirer_relation_data):
             logger.debug("Relation data did not pass JSON Schema validation")
             return
@@ -1169,9 +1171,7 @@ class TLSCertificatesProvidesV2(Object):
         )
         if not certificates_relation:
             raise RuntimeError(f"Relation {self.relationship_name} does not exist")
-        provider_relation_data = self._load_relation_data(
-            certificates_relation.data[self.charm.app]
-        )
+        provider_relation_data = self._load_app_relation_data(certificates_relation)
         list_of_csrs: List[str] = []
         for unit in certificates_relation.units:
             requirer_relation_data = _load_relation_data(certificates_relation.data[unit])

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -48,12 +48,10 @@ async def test_given_charm_is_built_when_deployed_then_status_is_active(
     )
 
 
-async def test_given_charm_is_scaled_when_tls_requirer_is_related_then_certificate_is_created_and_passed_correctly(  # noqa: E501
+async def test_given_tls_requirer_is_deployed_and_related_then_certificate_is_created_and_passed_correctly(  # noqa: E501
     ops_test: OpsTest,
     build_and_deploy,
 ):
-    await ops_test.model.applications[APP_NAME].scale(2)
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], timeout=1000, wait_for_exact_units=2)
     await ops_test.model.add_relation(
         relation1=f"{APP_NAME}:certificates", relation2=f"{TLS_REQUIRER_CHARM_NAME}"
     )
@@ -67,6 +65,16 @@ async def test_given_charm_is_scaled_when_tls_requirer_is_related_then_certifica
     assert action_output["ca-certificate"] is not None
     assert action_output["chain"] is not None
     assert action_output["csr"] is not None
+
+
+async def test_given_charm_scaled_then_charm_does_not_crash(
+    ops_test: OpsTest,
+    build_and_deploy,
+):
+    await ops_test.model.applications[APP_NAME].scale(2)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], timeout=1000, wait_for_exact_units=2)
+    await ops_test.model.applications[APP_NAME].scale(1)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], timeout=1000, wait_for_exact_units=1)
 
 
 async def run_get_certificate_action(ops_test) -> dict:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +20,7 @@ TLS_REQUIRER_CHARM_NAME = "tls-certificates-requirer"
 
 @pytest.fixture(scope="module")
 @pytest.mark.abort_on_fail
-async def build_and_deploy(ops_test):
+async def build_and_deploy(ops_test: OpsTest):
     """Build the charm-under-test and deploy it."""
     charm = await ops_test.build_charm(".")
     await ops_test.model.deploy(
@@ -37,7 +38,7 @@ async def build_and_deploy(ops_test):
 
 @pytest.mark.abort_on_fail
 async def test_given_charm_is_built_when_deployed_then_status_is_active(
-    ops_test,
+    ops_test: OpsTest,
     build_and_deploy,
 ):
     await ops_test.model.wait_for_idle(
@@ -47,10 +48,12 @@ async def test_given_charm_is_built_when_deployed_then_status_is_active(
     )
 
 
-async def test_given_tls_requirer_is_deployed_and_related_then_certificate_is_created_and_passed_correctly(  # noqa: E501
-    ops_test,
+async def test_given_charm_is_scaled_when_tls_requirer_is_related_then_certificate_is_created_and_passed_correctly(  # noqa: E501
+    ops_test: OpsTest,
     build_and_deploy,
 ):
+    await ops_test.model.applications[APP_NAME].scale(2)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], timeout=1000, wait_for_exact_units=2)
     await ops_test.model.add_relation(
         relation1=f"{APP_NAME}:certificates", relation2=f"{TLS_REQUIRER_CHARM_NAME}"
     )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -17,11 +17,11 @@ class TestCharm(unittest.TestCase):
     def setUp(self):
         self.harness = ops.testing.Harness(SelfSignedCertificatesCharm)
         self.addCleanup(self.harness.cleanup)
+        self.harness.set_leader(is_leader=True)
         self.harness.begin()
 
     def test_given_invalid_config_when_config_changed_then_status_is_blocked(self):
         key_values = {"ca-common-name": "", "certificate-validity": 100}
-        self.harness.set_leader(is_leader=True)
 
         self.harness.update_config(key_values=key_values)
 


### PR DESCRIPTION
# Description

This PR aims to fix https://github.com/canonical/self-signed-certificates-operator/issues/24 by bumping the library version to include the fix and it also adds tests for validation. Scale up operation does not crash the charm, after scaling a non-leader unit in this charm doesn't do anything.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
