### PR TITLE
feat: Handles outstanding cerfificate requests in main hook

### DIFF
--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -298,7 +298,7 @@ from ops.charm import (
 )
 from ops.framework import EventBase, EventSource, Handle, Object
 from ops.jujuversion import JujuVersion
-from ops.model import Relation, SecretNotFoundError
+from ops.model import ModelError, Relation, RelationDataContent, SecretNotFoundError
 
 # The unique Charmhub library identifier, never change it
 LIBID = "afd8c2bccf834997afce12c2706d2ede"
@@ -308,7 +308,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 19
+LIBPATCH = 20
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -600,23 +600,26 @@ class CertificateRevocationRequestEvent(EventBase):
         self.chain = snapshot["chain"]
 
 
-def _load_relation_data(raw_relation_data: dict) -> dict:
+def _load_relation_data(relation_data_content: RelationDataContent) -> dict:
     """Loads relation data from the relation data bag.
 
     Json loads all data.
 
     Args:
-        raw_relation_data: Relation data from the databag
+        relation_data_content: Relation data from the databag
 
     Returns:
         dict: Relation data in dict format.
     """
     certificate_data = dict()
-    for key in raw_relation_data:
-        try:
-            certificate_data[key] = json.loads(raw_relation_data[key])
-        except (json.decoder.JSONDecodeError, TypeError):
-            certificate_data[key] = raw_relation_data[key]
+    try:
+        for key in relation_data_content:
+            try:
+                certificate_data[key] = json.loads(relation_data_content[key])
+            except (json.decoder.JSONDecodeError, TypeError):
+                certificate_data[key] = relation_data_content[key]
+    except ModelError:
+        pass
     return certificate_data
 
 
@@ -1257,12 +1260,24 @@ class TLSCertificatesProvidesV2(Object):
                 )
                 self.remove_certificate(certificate=certificate["certificate"])
 
-    def get_requirer_csrs_with_no_certs(
+    def get_outstanding_certificate_requests(
         self, relation_id: Optional[int] = None
     ) -> List[Dict[str, Union[int, str, List[Dict[str, str]]]]]:
-        """Filters the requirer's units csrs.
+        """Returns CSR's for which no certificate has been issued.
 
-        Keeps the ones for which no certificate was provided.
+        Example return: [
+            {
+                "relation_id": 0,
+                "application_name": "tls-certificates-requirer",
+                "unit_name": "tls-certificates-requirer/0",
+                "unit_csrs": [
+                    {
+                        "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----...",
+                        "is_ca": false
+                    }
+                ]
+            }
+        ]
 
         Args:
             relation_id (int): Relation id
@@ -1279,6 +1294,7 @@ class TLSCertificatesProvidesV2(Object):
                 if not self.certificate_issued_for_csr(
                     app_name=unit_csr_mapping["application_name"],  # type: ignore[arg-type]
                     csr=csr["certificate_signing_request"],  # type: ignore[index]
+                    relation_id=relation_id,
                 ):
                     csrs_without_certs.append(csr)
             if csrs_without_certs:
@@ -1325,17 +1341,22 @@ class TLSCertificatesProvidesV2(Object):
                 )
         return unit_csr_mappings
 
-    def certificate_issued_for_csr(self, app_name: str, csr: str) -> bool:
+    def certificate_issued_for_csr(
+        self, app_name: str, csr: str, relation_id: Optional[int]
+    ) -> bool:
         """Checks whether a certificate has been issued for a given CSR.
 
         Args:
             app_name (str): Application name that the CSR belongs to.
             csr (str): Certificate Signing Request.
+            relation_id (int): Relation ID
 
         Returns:
             bool: True/False depending on whether a certificate has been issued for the given CSR.
         """
-        issued_certificates_per_csr = self.get_issued_certificates()[app_name]
+        issued_certificates_per_csr = self.get_issued_certificates(relation_id=relation_id)[
+            app_name
+        ]
         for issued_pair in issued_certificates_per_csr:
             if "csr" in issued_pair and issued_pair["csr"] == csr:
                 return csr_matches_certificate(csr, issued_pair["certificate"])

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -1349,8 +1349,7 @@ class TLSCertificatesProvidesV2(Object):
         Args:
             app_name (str): Application name that the CSR belongs to.
             csr (str): Certificate Signing Request.
-            relation_id (int): Relation ID
-
+            relation_id (Optional[int]): Relation ID
         Returns:
             bool: True/False depending on whether a certificate has been issued for the given CSR.
         """

--- a/src/charm.py
+++ b/src/charm.py
@@ -231,10 +231,19 @@ class SelfSignedCertificatesCharm(CharmBase):
             )
             return
         self._generate_self_signed_certificate(
-            csr=event.certificate_signing_request, is_ca=event.is_ca, relation_id=event.relation_id
+            csr=event.certificate_signing_request,
+            is_ca=event.is_ca,
+            relation_id=event.relation_id,
         )
 
-    def _generate_self_signed_certificate(self, csr: str, is_ca: bool, relation_id: int):
+    def _generate_self_signed_certificate(self, csr: str, is_ca: bool, relation_id: int) -> None:
+        """Generates self-signed certificate.
+
+        Args:
+            csr (str): Certificate signing request
+            is_ca (bool): Whether the certificate is a CA
+            relation_id (int): Relation id
+        """
         ca_certificate_secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
         ca_certificate_secret_content = ca_certificate_secret.get_content()
         certificate = generate_certificate(

--- a/src/charm.py
+++ b/src/charm.py
@@ -34,7 +34,6 @@ SEND_CA_CERT_REL_NAME = "send-ca-cert"  # Must match metadata
 
 def certificate_has_common_name(certificate: bytes, common_name: str) -> bool:
     """Returns whether the certificate has the given common name."""
-    print(certificate)
     loaded_certificate = x509.load_pem_x509_certificate(certificate)
     certificate_common_name = loaded_certificate.subject.get_attributes_for_oid(
         x509.oid.NameOID.COMMON_NAME

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 
 import ops
 import ops.testing
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus
 
 from charm import SelfSignedCertificatesCharm
 
@@ -107,6 +107,65 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
+    @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV2.set_relation_certificate")
+    @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV2.get_requirer_csrs_with_no_certs")
+    @patch("charm.generate_private_key")
+    @patch("charm.generate_password")
+    @patch("charm.generate_ca")
+    @patch("charm.generate_certificate")
+    def test_given_outstanding_certificate_requests_when_config_changed_then_requests_processed(
+        self,
+        patch_generate_certificate,
+        patch_generate_ca,
+        patch_generate_password,
+        patch_generate_private_key,
+        patch_get_requirer_csrs_with_no_certs,
+        patch_set_relation_certificate,
+    ):
+        validity = 100
+        relation_id = 123
+        ca = "whatever CA certificate"
+        private_key_password = "password"
+        private_key = "whatever private key"
+        requirer_csr = "whatever CSR"
+        requirer_is_ca = True
+        generated_certificate = "whatever certificate"
+        patch_generate_ca.return_value = ca.encode()
+        patch_generate_password.return_value = private_key_password
+        patch_generate_private_key.return_value = private_key.encode()
+        patch_get_requirer_csrs_with_no_certs.return_value = [
+            {
+                "relation_id": relation_id,
+                "unit_csrs": [
+                    {
+                        "certificate_signing_request": requirer_csr,
+                        "is_ca": requirer_is_ca,
+                    }
+                ],
+            }
+        ]
+        patch_generate_certificate.return_value = generated_certificate.encode()
+        key_values = {"ca-common-name": "pizza.com", "certificate-validity": validity}
+        self.harness.set_leader(is_leader=True)
+
+        self.harness.update_config(key_values=key_values)
+
+        patch_generate_certificate.assert_called_with(
+            ca=ca.encode(),
+            ca_key=private_key.encode(),
+            ca_key_password=private_key_password.encode(),
+            csr=requirer_csr.encode(),
+            validity=validity,
+            is_ca=requirer_is_ca,
+        )
+        patch_set_relation_certificate.assert_called_with(
+            certificate_signing_request=requirer_csr,
+            certificate=generated_certificate,
+            ca=ca,
+            chain=[ca, generated_certificate],
+            relation_id=relation_id,
+        )
+
     def test_given_invalid_config_when_certificate_request_then_status_is_blocked(self):
         self.harness.set_leader(is_leader=True)
         key_values = {"ca-common-name": "pizza.com", "certificate-validity": 0}
@@ -161,18 +220,6 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(
             ca_certificates_secret["private-key"],
             private_key_string,
-        )
-
-    def test_given_root_certificate_not_yet_generated_when_certificate_request_then_status_is_waiting(  # noqa: E501
-        self,
-    ):
-        self.harness.set_leader(is_leader=True)
-
-        self.harness.charm._on_certificate_creation_request(event=Mock())
-
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Root Certificate is not yet generated"),
         )
 
     @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV2.set_relation_certificate")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -108,7 +108,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
     @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV2.set_relation_certificate")
-    @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV2.get_requirer_csrs_with_no_certs")
+    @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV2.get_outstanding_certificate_requests")
     @patch("charm.generate_private_key")
     @patch("charm.generate_password")
     @patch("charm.generate_ca")
@@ -119,7 +119,7 @@ class TestCharm(unittest.TestCase):
         patch_generate_ca,
         patch_generate_password,
         patch_generate_private_key,
-        patch_get_requirer_csrs_with_no_certs,
+        patch_get_outstanding_certificate_requests,
         patch_set_relation_certificate,
     ):
         validity = 100
@@ -133,7 +133,7 @@ class TestCharm(unittest.TestCase):
         patch_generate_ca.return_value = ca.encode()
         patch_generate_password.return_value = private_key_password
         patch_generate_private_key.return_value = private_key.encode()
-        patch_get_requirer_csrs_with_no_certs.return_value = [
+        patch_get_outstanding_certificate_requests.return_value = [
             {
                 "relation_id": relation_id,
                 "unit_csrs": [
@@ -270,6 +270,7 @@ class TestCharm(unittest.TestCase):
             certificate_signing_request=certificate_signing_request,
         )
 
+    @patch("charm.certificate_has_common_name")
     @patch("charm.generate_private_key")
     @patch("charm.generate_password")
     @patch("charm.generate_ca")
@@ -278,7 +279,9 @@ class TestCharm(unittest.TestCase):
         patch_generate_ca,
         patch_generate_password,
         patch_generate_private_key,
+        patch_certificate_has_common_name,
     ):
+        patch_certificate_has_common_name.return_value = False
         initial_common_name = "common-name-initial.com"
         new_common_name = "common-name-new.com"
         ca_certificate_1_string = "whatever CA certificate 1"


### PR DESCRIPTION
# Description

Handles outstanding cerfificate requests in main hook and gets rid of `event.defer()`. This PR depends on the following PR being merged first: 
- https://github.com/canonical/tls-certificates-interface/pull/87

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
