### PR TITLE
feat: Add arm64 architecture support

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -6,20 +6,27 @@ bases:
   - build-on:
     - name: ubuntu
       channel: "22.04"
+      architectures:
+        - amd64
     run-on:
     - name: ubuntu
       channel: "22.04"
+      architectures:
+        - amd64
+  - build-on:
+    - name: ubuntu
+      channel: "22.04"
+      architectures:
+        - arm64
+    run-on:
+    - name: ubuntu
+      channel: "22.04"
+      architectures:
+        - arm64
 
 parts:
   charm:
     charm-binary-python-packages:
-      # This is a dev tool, so there is no issue with using binary packages in favor of build time
       - cryptography
       - jsonschema
       - ops >= 2.2.0
-#    build-packages:
-#      - libffi-dev
-#      - libssl-dev
-#      - rustc
-#      - cargo
-#      - pkg-config


### PR DESCRIPTION
# Description

Adds support for building the charm for arm64. Currently does not automatically build or publish the charm for that architecture.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
