### PR TITLE
fix: Refreshes secret content before getting its content

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -148,7 +148,6 @@ class SelfSignedCertificatesCharm(CharmBase):
         }
         if self._root_certificate_is_stored:
             secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
-            print(secret_content)
             secret.set_content(content=secret_content)
         else:
             self.app.add_secret(

--- a/src/charm.py
+++ b/src/charm.py
@@ -148,6 +148,7 @@ class SelfSignedCertificatesCharm(CharmBase):
         }
         if self._root_certificate_is_stored:
             secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
+            print(secret_content)
             secret.set_content(content=secret_content)
         else:
             self.app.add_secret(
@@ -185,7 +186,7 @@ class SelfSignedCertificatesCharm(CharmBase):
         if not self._config_ca_common_name:
             raise ValueError("CA common name should not be empty")
         ca_certificate_secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
-        ca_certificate_secret_content = ca_certificate_secret.get_content(refresh=True)
+        ca_certificate_secret_content = ca_certificate_secret.get_content()
         ca = ca_certificate_secret_content["ca-certificate"].encode()
         return certificate_has_common_name(certificate=ca, common_name=self._config_ca_common_name)
 
@@ -245,7 +246,7 @@ class SelfSignedCertificatesCharm(CharmBase):
             relation_id (int): Relation id
         """
         ca_certificate_secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
-        ca_certificate_secret_content = ca_certificate_secret.get_content(refresh=True)
+        ca_certificate_secret_content = ca_certificate_secret.get_content()
         certificate = generate_certificate(
             ca=ca_certificate_secret_content["ca-certificate"].encode(),
             ca_key=ca_certificate_secret_content["private-key"].encode(),
@@ -273,7 +274,7 @@ class SelfSignedCertificatesCharm(CharmBase):
             event.fail("Root Certificate is not yet generated")
             return
         ca_certificate_secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
-        ca_certificate_secret_content = ca_certificate_secret.get_content(refresh=True)
+        ca_certificate_secret_content = ca_certificate_secret.get_content()
         event.set_results({"ca-certificate": ca_certificate_secret_content["ca-certificate"]})
 
     def _on_send_ca_cert_relation_joined(self, event: RelationJoinedEvent):
@@ -288,7 +289,7 @@ class SelfSignedCertificatesCharm(CharmBase):
         send_ca_cert = CertificateTransferProvides(self, SEND_CA_CERT_REL_NAME)
         if self._root_certificate_is_stored:
             secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
-            secret_content = secret.get_content(refresh=True)
+            secret_content = secret.get_content()
             ca = secret_content["ca-certificate"]
             if rel_id:
                 send_ca_cert.set_certificate("", ca, [], relation_id=rel_id)

--- a/src/charm.py
+++ b/src/charm.py
@@ -185,7 +185,7 @@ class SelfSignedCertificatesCharm(CharmBase):
         if not self._config_ca_common_name:
             raise ValueError("CA common name should not be empty")
         ca_certificate_secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
-        ca_certificate_secret_content = ca_certificate_secret.get_content()
+        ca_certificate_secret_content = ca_certificate_secret.get_content(refresh=True)
         ca = ca_certificate_secret_content["ca-certificate"].encode()
         return certificate_has_common_name(certificate=ca, common_name=self._config_ca_common_name)
 
@@ -245,7 +245,7 @@ class SelfSignedCertificatesCharm(CharmBase):
             relation_id (int): Relation id
         """
         ca_certificate_secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
-        ca_certificate_secret_content = ca_certificate_secret.get_content()
+        ca_certificate_secret_content = ca_certificate_secret.get_content(refresh=True)
         certificate = generate_certificate(
             ca=ca_certificate_secret_content["ca-certificate"].encode(),
             ca_key=ca_certificate_secret_content["private-key"].encode(),
@@ -273,7 +273,7 @@ class SelfSignedCertificatesCharm(CharmBase):
             event.fail("Root Certificate is not yet generated")
             return
         ca_certificate_secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
-        ca_certificate_secret_content = ca_certificate_secret.get_content()
+        ca_certificate_secret_content = ca_certificate_secret.get_content(refresh=True)
         event.set_results({"ca-certificate": ca_certificate_secret_content["ca-certificate"]})
 
     def _on_send_ca_cert_relation_joined(self, event: RelationJoinedEvent):
@@ -288,7 +288,7 @@ class SelfSignedCertificatesCharm(CharmBase):
         send_ca_cert = CertificateTransferProvides(self, SEND_CA_CERT_REL_NAME)
         if self._root_certificate_is_stored:
             secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
-            secret_content = secret.get_content()
+            secret_content = secret.get_content(refresh=True)
             ca = secret_content["ca-certificate"]
             if rel_id:
                 send_ca_cert.set_certificate("", ca, [], relation_id=rel_id)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -302,17 +302,19 @@ class TestCharm(unittest.TestCase):
 
         self.harness.update_config(key_values={"ca-common-name": new_common_name})
 
-        ca_certificates_secret = self.harness._backend.secret_get(label="ca-certificates")
+        ca_certificates_secret = self.harness.model.get_secret(label="ca-certificates")
+
+        secret_content = ca_certificates_secret.get_content(refresh=True)
         self.assertEqual(
-            ca_certificates_secret["ca-certificate"],
+            secret_content["ca-certificate"],
             ca_certificate_2_string,
         )
         self.assertEqual(
-            ca_certificates_secret["private-key-password"],
+            secret_content["private-key-password"],
             private_key_password_2,
         )
         self.assertEqual(
-            ca_certificates_secret["private-key"],
+            secret_content["private-key"],
             private_key_string_2,
         )
 


### PR DESCRIPTION
# Description

This PR fixes an issue in tests where the content wasn't refreshed when getting a secret and it was possible to retrieve an old version of a secret instead of the latest one.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
