### PR TITLE
fix: Remove chain validation from integration tests

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -63,7 +63,6 @@ async def test_given_tls_requirer_is_deployed_and_related_then_certificate_is_cr
     action_output = await run_get_certificate_action(ops_test)
     assert action_output["certificate"] is not None
     assert action_output["ca-certificate"] is not None
-    assert action_output["chain"] is not None
     assert action_output["csr"] is not None
 
 


### PR DESCRIPTION
# Description

The tls-certificates requirer doesn't store ca chains anymore and won't return them in the `get-certificate` juju action (reference below). Here when we run the `get-certificate` action, we don't look at the ca chain anymore. This fixes an issue currently in main that prevents integration tests from running correctly.

## Reference
- https://github.com/canonical/tls-certificates-requirer-operator/pull/39

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
