### PR TITLE
fix: Passes CHARMCRAFT_AUTH secret to check-libraries.yaml workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,8 @@ on:
 jobs:
   check-libraries:
     uses: ./.github/workflows/check-libraries.yaml
-    secrets: inherit
+    secrets:
+      CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
 
   lint-report:
     uses: ./.github/workflows/lint-report.yaml


### PR DESCRIPTION
# Description

Passes CHARMCRAFT_AUTH secret to check-libraries.yaml workflow.
This should fix failing CI on dependabot PRs.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
