### PR TITLE
fix: Build Python packages from source instead of using `binary-python-packages`

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -26,6 +26,8 @@ bases:
 
 parts:
   charm:
+    build-packages:
+      - cargo
     charm-binary-python-packages:
       - cryptography
       - jsonschema

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -28,6 +28,7 @@ parts:
   charm:
     build-packages:
       - cargo
+      - libffi-dev
       - libssl-dev
       - pkg-config
       - rustc

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -28,7 +28,6 @@ parts:
   charm:
     build-packages:
       - cargo
-    charm-binary-python-packages:
-      - cryptography
-      - jsonschema
-      - ops >= 2.2.0
+      - libssl-dev
+      - pkg-config
+      - rustc


### PR DESCRIPTION
# Description

Build Python packages from source instead of using `binary-python-packages`. This fixes an issue with the current build in main.

## Logs

```
::    ::   error: subprocess-exited-with-error
::    ::
::    ::   × Preparing metadata (pyproject.toml) did not run successfully.
::    ::   │ exit code: 1
::    ::   ╰─> [6 lines of output]
::    ::
::    ::       Cargo, the Rust package manager, is not installed or is not on PATH.
::    ::       This package requires Rust and Cargo to compile extensions. Install it through
::    ::       the system's package manager or via https://rustup.rs/
::    ::
```

## Reference
- [CI failure in `main`](https://github.com/canonical/self-signed-certificates-operator/actions/runs/7899097564/job/21566024034)


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
