### PR TITLE
fix: Adds on pull_request event as a trigger of the CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,9 @@
 name: Main
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
   schedule:
     - cron: '0 0 * * 0'


### PR DESCRIPTION
# Description

Adds on pull_request event as a trigger of the CI, this is important so PRs created from forks can trigger the CI.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
