### PR TITLE
fix: tell type checkers that the config options are strings

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -8,7 +8,7 @@ import datetime
 import json
 import logging
 import secrets
-from typing import Optional
+from typing import Optional, cast
 
 from charms.certificate_transfer_interface.v0.certificate_transfer import (
     CertificateTransferProvides,
@@ -112,7 +112,7 @@ class SelfSignedCertificatesCharm(CharmBase):
         Returns:
             str: Common name
         """
-        return self.model.config.get("ca-common-name", None)
+        return cast(Optional[str], self.model.config.get("ca-common-name", None))
 
     @property
     def _root_certificate_is_stored(self) -> bool:


### PR DESCRIPTION
# Description

ops<=2.12 wrongly has `self.config[x]` typed as `str`, when actually it could be an int, float, bool, or str, depending on the config type. We're fixing this in [ops:#1183](https://github.com/canonical/operator/pull/1183), but that will break static checking that currently assumes that the config is a str (because ops doesn't validate the schema, so all options will be bool|int|float|str).

This PR adds a `typing.cast` call where the config values are loaded and used where the type should be str.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation N/A
- [ ] I have added tests that validate the behaviour of the software N/A
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules N/A
- [ ] I have bumped the version of the library N/A
