### PR TITLE
fix: generate new ca cert on config changed

### DIFF
--- a/tests/integration/certificates.py
+++ b/tests/integration/certificates.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from cryptography import x509
+
+
+def get_common_name_from_certificate(certificate: bytes) -> str:
+    loaded_certificate = x509.load_pem_x509_certificate(certificate)
+    return str(loaded_certificate.subject.get_attributes_for_oid(
+        x509.oid.NameOID.COMMON_NAME  # type: ignore[reportAttributeAccessIssue]
+    )[0].value)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -4,10 +4,13 @@
 
 
 import logging
+import time
 from pathlib import Path
+from typing import Dict
 
 import pytest
 import yaml
+from certificates import get_common_name_from_certificate
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -16,6 +19,27 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 TLS_REQUIRER_CHARM_NAME = "tls-certificates-requirer"
+CA_COMMON_NAME = "example.com"
+
+
+async def wait_for_requirer_ca_certificate(ops_test: OpsTest, ca_common_name: str) -> None:
+    """Wait for the certificate to be provided to the `tls-requirer-requirer/0` unit."""
+    t0 = time.time()
+    timeout = 300
+    while time.time() - t0 < timeout:
+        logger.info("Waiting for CA certificate with common name %s", ca_common_name)
+        time.sleep(5)
+        action_output = await run_get_certificate_action(ops_test)
+        ca_certificate = action_output.get("ca-certificate", "")
+        if not ca_certificate:
+            continue
+        existing_ca_common_name = get_common_name_from_certificate(ca_certificate.encode())
+        if existing_ca_common_name != ca_common_name:
+            logger.info("Existing CA Common Name: %s", existing_ca_common_name)
+            continue
+        logger.info("Certificate with CA common name %s provided", ca_common_name)
+        return
+    raise TimeoutError("Timed out waiting for certificate")
 
 
 @pytest.fixture(scope="module")
@@ -29,6 +53,7 @@ async def build_and_deploy(ops_test: OpsTest):
         application_name=APP_NAME,
         series="jammy",
         trust=True,
+        config={"ca-common-name": CA_COMMON_NAME},
     )
     await ops_test.model.deploy(
         TLS_REQUIRER_CHARM_NAME,
@@ -50,12 +75,12 @@ async def test_given_charm_is_built_when_deployed_then_status_is_active(
     )
 
 
-async def test_given_tls_requirer_is_deployed_and_related_then_certificate_is_created_and_passed_correctly(  # noqa: E501
+async def test_given_tls_requirer_is_deployed_when_integrated_then_certificate_is_provided(
     ops_test: OpsTest,
     build_and_deploy,
 ):
     assert ops_test.model
-    await ops_test.model.add_relation(
+    await ops_test.model.integrate(
         relation1=f"{APP_NAME}:certificates", relation2=f"{TLS_REQUIRER_CHARM_NAME}"
     )
     await ops_test.model.wait_for_idle(
@@ -63,10 +88,24 @@ async def test_given_tls_requirer_is_deployed_and_related_then_certificate_is_cr
         status="active",
         timeout=1000,
     )
-    action_output = await run_get_certificate_action(ops_test)
-    assert action_output["certificate"] is not None
-    assert action_output["ca-certificate"] is not None
-    assert action_output["csr"] is not None
+    await wait_for_requirer_ca_certificate(ops_test=ops_test, ca_common_name=CA_COMMON_NAME)
+
+async def test_given_tls_requirer_is_integrated_when_ca_common_name_config_changed_then_new_certificate_is_provided(  # noqa: E501
+    ops_test: OpsTest,
+    build_and_deploy,
+):
+    new_common_name = "newexample.org"
+    assert ops_test.model
+    application = ops_test.model.applications[APP_NAME]
+    assert application
+    await application.set_config({"ca-common-name": new_common_name})
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, TLS_REQUIRER_CHARM_NAME],
+        status="active",
+        timeout=1000,
+    )
+
+    await wait_for_requirer_ca_certificate(ops_test=ops_test, ca_common_name=new_common_name)
 
 
 async def test_given_charm_scaled_then_charm_does_not_crash(
@@ -80,7 +119,7 @@ async def test_given_charm_scaled_then_charm_does_not_crash(
     await ops_test.model.wait_for_idle(apps=[APP_NAME], timeout=1000, wait_for_exact_units=1)
 
 
-async def run_get_certificate_action(ops_test) -> dict:
+async def run_get_certificate_action(ops_test) -> Dict[str, str]:
     """Run `get-certificate` on the `tls-requirer-requirer/0` unit.
 
     Args:
@@ -91,8 +130,6 @@ async def run_get_certificate_action(ops_test) -> dict:
     """
     assert ops_test.model
     tls_requirer_unit = ops_test.model.units[f"{TLS_REQUIRER_CHARM_NAME}/0"]
-    action = await tls_requirer_unit.run_action(
-        action_name="get-certificate",
-    )
+    action = await tls_requirer_unit.run_action(action_name="get-certificate")
     action_output = await ops_test.model.get_action_output(action_uuid=action.entity_id, wait=240)
     return action_output


### PR DESCRIPTION
# Description

There is a bug where on ca common name config changed, the self-signed certificates charm would generate a new CA, store it in a secret but we would read the secret in the same event handler and it would be the old secret.

Now, we return after changing the root CA certificate and updating the secret and we observe the "secret_changed" event. This allows for reading the new ca certificate instead of reading the old one. 

Fixes #132 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
