### PR TITLE
chore: Automatically build charm for arm64

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,14 @@ on:
 
 jobs:
   build-charm-under-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: [self-hosted, linux, ARM64, medium, jammy]
+    runs-on: ${{ matrix.arch.runner }}
     steps:
       - uses: actions/checkout@v4
     
@@ -23,6 +30,6 @@ jobs:
       - name: Archive Charm Under Test
         uses: actions/upload-artifact@v4
         with:
-          name: built-charm
+          name: built-charm-${{ matrix.arch.arch }}
           path: "*.charm"
           retention-days: 5

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -5,15 +5,22 @@ on:
 
 jobs:
   integration-test:
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        arch:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: [self-hosted, linux, ARM64, medium, jammy]
+    runs-on: ${{ matrix.arch.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Fetch Charm Under Test
         uses: actions/download-artifact@v4
         with:
-          name: built-charm
+          name: built-charm-${{ matrix.arch.arch }}
           path: built/
       
       - name: Get Charm Under Test Path
@@ -31,7 +38,7 @@ jobs:
       - name: Run integration tests
         run: |
           tox -e integration -- \
-            --charm_path="${{ steps.charm-path.outputs.charm_path }}" \
+            --charm_path=${{ steps.charm-path.outputs.charm_path }}
   
       - name: Archive charmcraft logs
         if: failure()

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -8,7 +8,14 @@ on:
 
 jobs:
   publish-charm:
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        arch:
+          - arch: amd64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: [self-hosted, linux, ARM64, medium, jammy]
+    runs-on: ${{ matrix.arch.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,7 +26,7 @@ jobs:
       - name: Fetch Tested Charm
         uses: actions/download-artifact@v4
         with:
-          name: built-charm
+          name: built-charm-${{ matrix.arch.arch }}
       
       - name: Get Charm Under Test Path
         id: charm-path


### PR DESCRIPTION
# Description

This updates the CI to automatically build, test and upload the charm for arm64. It uses self-hosted arm64 runners for the arm64 specific jobs.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
