### PR TITLE
style: Format using ruff

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 CA_CERTIFICATES_SECRET_LABEL = "ca-certificates"
 SEND_CA_CERT_REL_NAME = "send-ca-cert"  # Must match metadata
 
+
 def certificate_has_common_name(certificate: bytes, common_name: str) -> bool:
     """Return whether the certificate has the given common name."""
     loaded_certificate = x509.load_pem_x509_certificate(certificate)
@@ -45,9 +46,7 @@ def certificate_has_common_name(certificate: bytes, common_name: str) -> bool:
 
 @trace_charm(
     tracing_endpoint="tempo_otlp_http_endpoint",
-    extra_types=(
-        TLSCertificatesProvidesV3,
-    ),
+    extra_types=(TLSCertificatesProvidesV3,),
 )
 class SelfSignedCertificatesCharm(CharmBase):
     """Main class to handle Juju events."""
@@ -76,16 +75,18 @@ class SelfSignedCertificatesCharm(CharmBase):
         )
 
     def _on_collect_unit_status(self, event: CollectStatusEvent):
-         """Centralized status management for the charm."""
-         if not self.unit.is_leader():
+        """Centralized status management for the charm."""
+        if not self.unit.is_leader():
             event.add_status(BlockedStatus("Scaling is not implemented for this charm"))
             return
-         if invalid_configs := self._invalid_configs():
-            event.add_status(BlockedStatus(
-                f"The following configuration values are not valid: {invalid_configs}"
-            ))
+        if invalid_configs := self._invalid_configs():
+            event.add_status(
+                BlockedStatus(
+                    f"The following configuration values are not valid: {invalid_configs}"
+                )
+            )
             return
-         event.add_status(ActiveStatus())
+        event.add_status(ActiveStatus())
 
     @property
     def _config_root_ca_certificate_validity(self) -> int:
@@ -111,9 +112,7 @@ class SelfSignedCertificatesCharm(CharmBase):
         if not certificates:
             event.fail("No certificates issued yet.")
             return
-        results = {
-            "certificates": [certificate.to_json() for certificate in certificates]
-        }
+        results = {"certificates": [certificate.to_json() for certificate in certificates]}
         event.set_results(results)
 
     @property
@@ -324,7 +323,7 @@ class SelfSignedCertificatesCharm(CharmBase):
     def tempo_otlp_http_endpoint(self) -> Optional[str]:
         """Tempo endpoint for charm tracing."""
         if self.tracing.is_ready():
-            return self.tracing.get_endpoint('otlp_http')
+            return self.tracing.get_endpoint("otlp_http")
         else:
             return None
 

--- a/tests/integration/certificates.py
+++ b/tests/integration/certificates.py
@@ -7,6 +7,8 @@ from cryptography import x509
 
 def get_common_name_from_certificate(certificate: bytes) -> str:
     loaded_certificate = x509.load_pem_x509_certificate(certificate)
-    return str(loaded_certificate.subject.get_attributes_for_oid(
-        x509.oid.NameOID.COMMON_NAME  # type: ignore[reportAttributeAccessIssue]
-    )[0].value)
+    return str(
+        loaded_certificate.subject.get_attributes_for_oid(
+            x509.oid.NameOID.COMMON_NAME  # type: ignore[reportAttributeAccessIssue]
+        )[0].value
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,11 +16,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
       parser: The pytest command line parser.
     """
     parser.addoption(
-        "--charm_path",
-        action="store",
-        default=None,
-        help="Path to the charm under test"
+        "--charm_path", action="store", default=None, help="Path to the charm under test"
     )
+
 
 def pytest_configure(config: pytest.Config) -> None:
     """Validate the options provided by the user.

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -97,6 +97,7 @@ async def test_given_tls_requirer_is_deployed_when_integrated_then_certificate_i
     )
     await wait_for_requirer_ca_certificate(ops_test=ops_test, ca_common_name=CA_COMMON_NAME)
 
+
 async def test_given_tls_requirer_is_integrated_when_ca_common_name_config_changed_then_new_certificate_is_provided(  # noqa: E501
     ops_test: OpsTest,
     deploy,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -145,7 +145,7 @@ class TestCharm(unittest.TestCase):
 
         self.harness.update_config(key_values=key_values)
 
-        secret =self.harness.model.get_secret(label="ca-certificates")
+        secret = self.harness.model.get_secret(label="ca-certificates")
         secret_content = secret.get_content(refresh=True)
         assert secret_content["ca-certificate"] == new_ca
 
@@ -365,7 +365,8 @@ class TestCharm(unittest.TestCase):
 
     @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV3.get_issued_certificates")
     def test_given_certificates_issued_when_get_issued_certificates_action_then_action_returns_certificates(  # noqa: E501
-        self, patch_get_issued_certificates,
+        self,
+        patch_get_issued_certificates,
     ):
         relation_id = 123
         application_name = "tls-requirer"
@@ -379,25 +380,24 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader(is_leader=True)
         patch_get_issued_certificates.return_value = [
             ProviderCertificate(
-                relation_id = relation_id,
-                application_name = application_name,
-                csr = csr,
-                certificate = certificate,
-                ca = ca_certificate,
-                chain = chain,
-                revoked = revoked,
-                expiry_time = expiry_time,
-                expiry_notification_time = expiry_notification_time,
+                relation_id=relation_id,
+                application_name=application_name,
+                csr=csr,
+                certificate=certificate,
+                ca=ca_certificate,
+                chain=chain,
+                revoked=revoked,
+                expiry_time=expiry_time,
+                expiry_notification_time=expiry_notification_time,
             )
         ]
 
         action_output = self.harness.run_action("get-issued-certificates")
 
         expected_certificates = {
-            "certificates":
-                [
-                    json.dumps(
-                        {
+            "certificates": [
+                json.dumps(
+                    {
                         "relation_id": relation_id,
                         "application_name": application_name,
                         "csr": csr,
@@ -407,9 +407,9 @@ class TestCharm(unittest.TestCase):
                         "revoked": revoked,
                         "expiry_time": expiry_time.isoformat(),
                         "expiry_notification_time": expiry_notification_time,
-                        }
-                    )
-                ]
+                    }
+                )
+            ]
         }
 
         self.assertEqual(action_output.results, expected_certificates)

--- a/tox.ini
+++ b/tox.ini
@@ -30,17 +30,19 @@ pass_env =
 description = Apply coding style standards to code
 commands =
     ruff check --fix {[vars]all_path}
+    ruff format {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
     codespell {tox_root}
     ruff check {[vars]all_path}
+    ruff format --check {[vars]all_path}
 
 [testenv:static]
 description = Run static type checks
 commands =
-    pyright {[vars]all_path}
+    pyright {[vars]all_path} {posargs}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
Currently, ruff is only configured to check the files for linting errors. This adds ruff formatting to tox checks.

Review notes:

Only tox.ini contains functional changes, the rest are the result of running tox -e format.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
