### PR TITLE
fix: Fixes secret expiry to use the correct config value

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -165,7 +165,7 @@ class SelfSignedCertificatesCharm(CharmBase):
             self.app.add_secret(
                 content=secret_content,
                 label=CA_CERTIFICATES_SECRET_LABEL,
-                expire=datetime.timedelta(days=self._config_certificate_validity),
+                expire=datetime.timedelta(days=self._config_root_ca_certificate_validity),
             )
         logger.info("Root certificates generated and stored.")
 


### PR DESCRIPTION
# Description

The expiry of the secret holding the root ca should be equal to the root ca expiry.
Fixes #214 

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
