### PR TITLE
feat: add CA certificate attribute config options

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -77,6 +77,24 @@ config:
       type: string
       default: self-signed-certificates-operator
       description: Common name to be used by the Certificate Authority.
+    ca-organization:
+      type: string
+      description: Organization name to be used by the Certificate Authority.
+    ca-organizational-unit:
+      type: string
+      description: Organizational unit to be used by the Certificate Authority.
+    ca-email-address:
+      type: string
+      description: Email address to be used by the Certificate Authority.
+    ca-country-name:
+      type: string
+      description: Country name to be used by the Certificate Authority.
+    ca-state-or-province-name:
+      type: string
+      description: State or province name to be used by the Certificate Authority.
+    ca-locality-name:
+      type: string
+      description: Locality name to be used by the Certificate Authority.
     root-ca-validity:
       type: int
       default: 365

--- a/src/charm.py
+++ b/src/charm.py
@@ -121,15 +121,31 @@ class SelfSignedCertificatesCharm(CharmBase):
 
     @property
     def _config_ca_common_name(self) -> Optional[str]:
-        """Returns the user provided common name.
-
-         This common name should only be used when the 'generate-self-signed-certificates' config
-         is set to True.
-
-        Returns:
-            str: Common name
-        """
         return cast(Optional[str], self.model.config.get("ca-common-name", None))
+
+    @property
+    def _config_ca_organization(self) -> Optional[str]:
+        return cast(Optional[str], self.model.config.get("ca-organization", None))
+
+    @property
+    def _config_ca_organizational_unit(self) -> Optional[str]:
+        return cast(Optional[str], self.model.config.get("ca-organizational-unit", None))
+
+    @property
+    def _config_ca_email_address(self) -> Optional[str]:
+        return cast(Optional[str], self.model.config.get("ca-email-address", None))
+
+    @property
+    def _config_ca_country_name(self) -> Optional[str]:
+        return cast(Optional[str], self.model.config.get("ca-country-name", None))
+
+    @property
+    def _config_ca_state_or_province_name(self) -> Optional[str]:
+        return cast(Optional[str], self.model.config.get("ca-state-or-province-name", None))
+
+    @property
+    def _config_ca_locality_name(self) -> Optional[str]:
+        return cast(Optional[str], self.model.config.get("ca-locality-name", None))
 
     @property
     def _root_certificate_is_stored(self) -> bool:
@@ -157,6 +173,12 @@ class SelfSignedCertificatesCharm(CharmBase):
         ca_certificate = generate_ca(
             private_key=private_key,
             common_name=self._config_ca_common_name,
+            organization=self._config_ca_organization,
+            organizational_unit=self._config_ca_organizational_unit,
+            email_address=self._config_ca_email_address,
+            country_name=self._config_ca_country_name,
+            state_or_province_name=self._config_ca_state_or_province_name,
+            locality_name=self._config_ca_locality_name,
             validity=self._config_root_ca_certificate_validity,
         )
         self._push_ca_cert_to_container(str(ca_certificate))

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -205,6 +205,9 @@ class TestCharm:
         state_in = scenario.State(
             config={
                 "ca-common-name": "pizza.com",
+                "ca-email-address": "abc@gmail.com",
+                "ca-country-name": "CA",
+                "ca-locality-name": "Montreal",
                 "certificate-validity": 100,
             },
             leader=True,
@@ -216,6 +219,17 @@ class TestCharm:
         ca_certificates_secret = state_out.secrets[0]
         secret_content = ca_certificates_secret.contents
         assert secret_content[1]["ca-certificate"] == str(new_ca)
+        patch_generate_ca.assert_called_with(
+            private_key=ca_private_key,
+            common_name="pizza.com",
+            organization=None,
+            organizational_unit=None,
+            email_address="abc@gmail.com",
+            country_name="CA",
+            state_or_province_name=None,
+            locality_name="Montreal",
+            validity=365,
+        )
 
     @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV4.set_relation_certificate")
     @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV4.get_outstanding_certificate_requests")


### PR DESCRIPTION
# Description

No attributes were configurable for the CA certificate. By default, the country was set to `US` however. Here we remove this default and allow users to configure their CA certificate attributes. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
