### PR TITLE
feat: Implement CA certificate renewal

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -98,11 +98,11 @@ config:
     root-ca-validity:
       type: int
       default: 365
-      description: RootCA certificate validity (in days), should longer than twice of certificate-validity. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
+      description: RootCA certificate validity (in days). This value should be longer than twice the certificate-validity. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
     certificate-validity:
       type: int
       default: 90
-      description: Certificate validity (in days) must be shorter than half the root-ca-validity. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
+      description: Certificate validity (in days). This value must be shorter than half the root-ca-validity. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
     validity-unit:
       type: string
       default: days

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -147,6 +147,3 @@ actions:
 
   get-issued-certificates:
     description: Outputs the certificates issued by the charm.
-
-  rotate-private-key:
-    description: Generates a new private key, new CA certificate and revokes previously issued certificates.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -76,37 +76,37 @@ config:
     ca-common-name:
       type: string
       default: self-signed-certificates-operator
-      description: Common name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate.
+      description: Common name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
     ca-organization:
       type: string
-      description: Organization name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate.
+      description: Organization name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
     ca-organizational-unit:
       type: string
-      description: Organizational unit to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate.
+      description: Organizational unit to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
     ca-email-address:
       type: string
-      description: Email address to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate.
+      description: Email address to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
     ca-country-name:
       type: string
-      description: Country name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate.
+      description: Country name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
     ca-state-or-province-name:
       type: string
-      description: State or province name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate.
+      description: State or province name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
     ca-locality-name:
       type: string
-      description: Locality name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate.
+      description: Locality name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
     root-ca-validity:
       type: int
       default: 365
-      description: RootCA certificate validity (in days), should longer than twice of certificate-validity. Changing this value will trigger generation of a new CA certificate.
+      description: RootCA certificate validity (in days), should longer than twice of certificate-validity. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
     certificate-validity:
       type: int
       default: 90
-      description: Certificate validity (in days) must be shorter than half the root-ca-validity. Changing this value will trigger generation of a new CA certificate.
+      description: Certificate validity (in days) must be shorter than half the root-ca-validity. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
     validity-unit:
       type: string
       default: days
-      description: Validity unit weeks, days, hours, minutes or seconds, it is days by default and will be applied to both root-ca-validity and certificate-validity. Changing this value will trigger generation of a new CA certificate.
+      description: Validity unit weeks, days, hours, minutes or seconds, it is days by default and will be applied to both root-ca-validity and certificate-validity. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
 
 actions:
   get-ca-certificate:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -125,7 +125,7 @@ config:
         For example, "15s" for 15 seconds, "10w" for 10 weeks. 
         If no units are given, the unit will be assumed as days.
         Defaults to 365 days.
-        This value should be longer than twice the certificate-validity.
+        This value should be equal to or longer than twice the certificate-validity.
         Changing this value will trigger generation of a new CA certificate,
         revoking all previously issued certificates.
     certificate-validity:
@@ -137,7 +137,7 @@ config:
         For example, "15s" for 15 seconds, "10w" for 10 weeks. 
         If no units are given, the unit will be assumed as days.
         Defaults to 90 days.
-        This value should be longer than twice the certificate-validity.
+        This value should be equal to or shorter than half the root-ca-validity.
         Changing this value will trigger generation of a new CA certificate,
         revoking all previously issued certificates.
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -121,8 +121,8 @@ config:
       default: 365d
       description: >
         RootCA certificate validity. 
-        The given value must be followed by one of: "s" for seconds, "h" for hours, "d" for days and "w" for weeks. 
-        For example, "15s" for 15 seconds, "10w" for 10 weeks. 
+        The given value must be followed by one of: "m" for minutes, "h" for hours, "d" for days and "w" for weeks. 
+        For example, "1m" for 1 minute, "10w" for 10 weeks.
         If no units are given, the unit will be assumed as days.
         Defaults to 365 days.
         This value should be equal to or longer than twice the certificate-validity.
@@ -133,8 +133,8 @@ config:
       default: 90d
       description: > 
         Signed certificate validity.
-        The given value must be followed by one of: "s" for seconds, "h" for hours, "d" for days and "w" for weeks. 
-        For example, "15s" for 15 seconds, "10w" for 10 weeks. 
+        The given value must be followed by one of: "m" for minutes, "h" for hours, "d" for days and "w" for weeks. 
+        For example, "1m" for 1 minute, "10w" for 10 weeks.
         If no units are given, the unit will be assumed as days.
         Defaults to 90 days.
         This value should be equal to or shorter than half the root-ca-validity.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -101,7 +101,7 @@ config:
       description: RootCA certificate validity (in days), should longer than twice of certificate-validity. Changing this value will trigger generation of a new CA certificate.
     certificate-validity:
       type: int
-      default: 365
+      default: 90
       description: Certificate validity (in days) must be shorter than half the root-ca-validity. Changing this value will trigger generation of a new CA certificate.
     validity-unit:
       type: string

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -76,33 +76,37 @@ config:
     ca-common-name:
       type: string
       default: self-signed-certificates-operator
-      description: Common name to be used by the Certificate Authority.
+      description: Common name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate.
     ca-organization:
       type: string
-      description: Organization name to be used by the Certificate Authority.
+      description: Organization name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate.
     ca-organizational-unit:
       type: string
-      description: Organizational unit to be used by the Certificate Authority.
+      description: Organizational unit to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate.
     ca-email-address:
       type: string
-      description: Email address to be used by the Certificate Authority.
+      description: Email address to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate.
     ca-country-name:
       type: string
-      description: Country name to be used by the Certificate Authority.
+      description: Country name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate.
     ca-state-or-province-name:
       type: string
-      description: State or province name to be used by the Certificate Authority.
+      description: State or province name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate.
     ca-locality-name:
       type: string
-      description: Locality name to be used by the Certificate Authority.
+      description: Locality name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate.
     root-ca-validity:
       type: int
       default: 365
-      description: RootCA certificate validity (in days), should longer than twice of certificate-validity.
+      description: RootCA certificate validity (in days), should longer than twice of certificate-validity. Changing this value will trigger generation of a new CA certificate.
     certificate-validity:
       type: int
       default: 365
-      description: Certificate validity (in days) must be shorter than half the root-ca-validity.
+      description: Certificate validity (in days) must be shorter than half the root-ca-validity. Changing this value will trigger generation of a new CA certificate.
+    validity-unit:
+      type: string
+      default: days
+      description: Validity unit weeks, days, hours, minutes or seconds, it is days by default and will be applied to both root-ca-validity and certificate-validity. Changing this value will trigger generation of a new CA certificate.
 
 actions:
   get-ca-certificate:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -98,11 +98,11 @@ config:
     root-ca-validity:
       type: int
       default: 365
-      description: RootCA certificate validity (in days).
+      description: RootCA certificate validity (in days), should longer than twice of certificate-validity.
     certificate-validity:
       type: int
       default: 365
-      description: Certificate validity (in days).
+      description: Certificate validity (in days) must be shorter than half the root-ca-validity.
 
 actions:
   get-ca-certificate:
@@ -110,3 +110,6 @@ actions:
 
   get-issued-certificates:
     description: Outputs the certificates issued by the charm.
+
+  rotate-private-key:
+    description: Generates a new private key, new CA certificate and revokes previously issued certificates.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -76,37 +76,70 @@ config:
     ca-common-name:
       type: string
       default: self-signed-certificates-operator
-      description: Common name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
+      description: >
+        Common name to be used by the Certificate Authority.
+        Changing this value will trigger generation of a new CA certificate,
+        revoking all previously issued certificates.
     ca-organization:
       type: string
-      description: Organization name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
+      description: >
+        Organization name to be used by the Certificate Authority.
+        Changing this value will trigger generation of a new CA certificate,
+        revoking all previously issued certificates.
     ca-organizational-unit:
       type: string
-      description: Organizational unit to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
+      description: >
+        Organizational unit to be used by the Certificate Authority.
+        Changing this value will trigger generation of a new CA certificate,
+        revoking all previously issued certificates.
     ca-email-address:
       type: string
-      description: Email address to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
+      description: >
+        Email address to be used by the Certificate Authority.
+        Changing this value will trigger generation of a new CA certificate,
+        revoking all previously issued certificates.
     ca-country-name:
       type: string
-      description: Country name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
+      description: >
+        Country name to be used by the Certificate Authority.
+        Changing this value will trigger generation of a new CA certificate,
+        revoking all previously issued certificates.
     ca-state-or-province-name:
       type: string
-      description: State or province name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
+      description: >
+        State or province name to be used by the Certificate Authority.
+        Changing this value will trigger generation of a new CA certificate,
+        revoking all previously issued certificates.
     ca-locality-name:
       type: string
-      description: Locality name to be used by the Certificate Authority. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
+      description: >
+        Locality name to be used by the Certificate Authority.
+        Changing this value will trigger generation of a new CA certificate,
+        revoking all previously issued certificates.
     root-ca-validity:
-      type: int
-      default: 365
-      description: RootCA certificate validity (in days). This value should be longer than twice the certificate-validity. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
-    certificate-validity:
-      type: int
-      default: 90
-      description: Certificate validity (in days). This value must be shorter than half the root-ca-validity. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
-    validity-unit:
       type: string
-      default: days
-      description: Validity unit weeks, days, hours, minutes or seconds, it is days by default and will be applied to both root-ca-validity and certificate-validity. Changing this value will trigger generation of a new CA certificate, revoking all previously issued certificates.
+      default: 365d
+      description: >
+        RootCA certificate validity. 
+        The given value must be followed by one of: "s" for seconds, "h" for hours, "d" for days and "y" for years. 
+        For example, "15s" for 15 seconds, "10y" for 10 years. 
+        If no units are given, the unit will be assumed as days.
+        Defaults to 365 days.
+        This value should be longer than twice the certificate-validity.
+        Changing this value will trigger generation of a new CA certificate,
+        revoking all previously issued certificates.
+    certificate-validity:
+      type: string
+      default: 90d
+      description: > 
+        Signed certificate validity.
+        The given value must be followed by one of: "s" for seconds, "h" for hours, "d" for days and "y" for years. 
+        For example, "15s" for 15 seconds, "10y" for 10 years. 
+        If no units are given, the unit will be assumed as days.
+        Defaults to 365 days.
+        This value should be longer than twice the certificate-validity.
+        Changing this value will trigger generation of a new CA certificate,
+        revoking all previously issued certificates.
 
 actions:
   get-ca-certificate:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -121,8 +121,8 @@ config:
       default: 365d
       description: >
         RootCA certificate validity. 
-        The given value must be followed by one of: "s" for seconds, "h" for hours, "d" for days and "y" for years. 
-        For example, "15s" for 15 seconds, "10y" for 10 years. 
+        The given value must be followed by one of: "s" for seconds, "h" for hours, "d" for days and "w" for weeks. 
+        For example, "15s" for 15 seconds, "10w" for 10 weeks. 
         If no units are given, the unit will be assumed as days.
         Defaults to 365 days.
         This value should be longer than twice the certificate-validity.
@@ -133,10 +133,10 @@ config:
       default: 90d
       description: > 
         Signed certificate validity.
-        The given value must be followed by one of: "s" for seconds, "h" for hours, "d" for days and "y" for years. 
-        For example, "15s" for 15 seconds, "10y" for 10 years. 
+        The given value must be followed by one of: "s" for seconds, "h" for hours, "d" for days and "w" for weeks. 
+        For example, "15s" for 15 seconds, "10w" for 10 weeks. 
         If no units are given, the unit will be assumed as days.
-        Defaults to 365 days.
+        Defaults to 90 days.
         This value should be longer than twice the certificate-validity.
         Changing this value will trigger generation of a new CA certificate,
         revoking all previously issued certificates.

--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -185,7 +185,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 PYDEPS = ["cryptography", "pydantic"]
 
@@ -862,7 +862,7 @@ def generate_csr(  # noqa: C901
 
 def generate_ca(
     private_key: PrivateKey,
-    validity: int,
+    validity: timedelta,
     common_name: str,
     sans_dns: Optional[FrozenSet[str]] = frozenset(),
     sans_ip: Optional[FrozenSet[str]] = frozenset(),
@@ -878,7 +878,7 @@ def generate_ca(
 
     Args:
         private_key (PrivateKey): Private key
-        validity (int): Certificate validity time (in days)
+        validity (timedelta): Certificate validity time
         common_name (str): Common Name that can be an IP or a Full Qualified Domain Name (FQDN).
         sans_dns (FrozenSet[str]): DNS Subject Alternative Names
         sans_ip (FrozenSet[str]): IP Subject Alternative Names
@@ -945,7 +945,7 @@ def generate_ca(
         .public_key(private_key_object.public_key())
         .serial_number(x509.random_serial_number())
         .not_valid_before(datetime.now(timezone.utc))
-        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=validity))
+        .not_valid_after(datetime.now(timezone.utc) + validity)
         .add_extension(x509.SubjectAlternativeName(set(_sans)), critical=False)
         .add_extension(x509.SubjectKeyIdentifier(digest=subject_identifier), critical=False)
         .add_extension(
@@ -971,7 +971,7 @@ def generate_certificate(
     csr: CertificateSigningRequest,
     ca: Certificate,
     ca_private_key: PrivateKey,
-    validity: int,
+    validity: timedelta,
     is_ca: bool = False,
 ) -> Certificate:
     """Generate a TLS certificate based on a CSR.
@@ -980,7 +980,7 @@ def generate_certificate(
         csr (CertificateSigningRequest): CSR
         ca (Certificate): CA Certificate
         ca_private_key (PrivateKey): CA private key
-        validity (int): Certificate validity (in days)
+        validity (timedelta): Certificate validity time
         is_ca (bool): Whether the certificate is a CA certificate
 
     Returns:
@@ -999,7 +999,7 @@ def generate_certificate(
         .public_key(csr_object.public_key())
         .serial_number(x509.random_serial_number())
         .not_valid_before(datetime.now(timezone.utc))
-        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=validity))
+        .not_valid_after(datetime.now(timezone.utc) + validity)
     )
     extensions = _get_certificate_request_extensions(
         authority_key_identifier=ca_pem.extensions.get_extension_for_class(
@@ -1792,6 +1792,22 @@ class TLSCertificatesProvidesV4(Object):
             for certificate in self._load_provider_certificates(relation):
                 certificates.append(certificate.to_provider_certificate(relation_id=relation.id))
         return certificates
+
+    def get_unsolicited_certificates(
+        self, relation_id: Optional[int] = None
+    ) -> List[ProviderCertificate]:
+        """Return provider certificates for which no certificate requests exists.
+
+        Those certificates should be revoked.
+        """
+        unsolicited_certificates: List[ProviderCertificate] = []
+        provider_certificates = self.get_provider_certificates(relation_id=relation_id)
+        requirer_csrs = self.get_certificate_requests(relation_id=relation_id)
+        list_of_csrs = [csr.certificate_signing_request for csr in requirer_csrs]
+        for certificate in provider_certificates:
+            if certificate.certificate_signing_request not in list_of_csrs:
+                unsolicited_certificates.append(certificate)
+        return unsolicited_certificates
 
     def get_outstanding_certificate_requests(
         self, relation_id: Optional[int] = None

--- a/src/charm.py
+++ b/src/charm.py
@@ -298,8 +298,9 @@ class SelfSignedCertificatesCharm(CharmBase):
     def _renew_root_certificate(self):
         """Generate a new active root CA certificate.
 
-        If there is an active CA certificate that is about to expire, generate a new one.
-        If there is no active CA certificate, generate a new one.
+        If there is a CA certificate that is about to expire,
+        move it to the expiring-ca-certificate secret.
+        Generate a new active CA certificate
         """
         if not self.unit.is_leader():
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -332,6 +332,7 @@ class SelfSignedCertificatesCharm(CharmBase):
             secret = self.model.get_secret(label=label)
             secret.set_content(content=content)
             secret.set_info(expire=expire)
+            secret.get_content(refresh=True)
         except SecretNotFoundError:
             self.app.add_secret(content=content, label=label, expire=expire)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -101,11 +101,7 @@ class SelfSignedCertificatesCharm(CharmBase):
 
     @property
     def _config_root_ca_certificate_validity(self) -> timedelta | None:
-        """Return Root CA certificate validity.
-
-        Returns:
-            int: Certificate validity
-        """
+        """Return Root CA certificate validity from the charm config as a timedelta object."""
         try:
             validity = self._parse_config_time_string(
                 str(self.model.config.get("root-ca-validity", ""))
@@ -117,11 +113,7 @@ class SelfSignedCertificatesCharm(CharmBase):
 
     @property
     def _config_certificate_validity(self) -> timedelta | None:
-        """Returns certificate validity (in seconds).
-
-        Returns:
-            int: Certificate validity (in seconds)
-        """
+        """Returns certificate validity from the charm config as a timedelta object."""
         try:
             validity = self._parse_config_time_string(
                 str(self.model.config.get("certificate-validity", ""))

--- a/src/charm.py
+++ b/src/charm.py
@@ -260,17 +260,11 @@ class SelfSignedCertificatesCharm(CharmBase):
             "private-key": str(private_key),
             "ca-certificate": str(ca_certificate),
         }
-        if self._root_certificate_is_stored:
-            secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
-            secret.set_content(content=secret_content)
-            secret.set_info(expire=self._ca_certificate_renewal_threshold)
-            secret.get_content(refresh=True)
-        else:
-            self.app.add_secret(
-                content=secret_content,
-                label=CA_CERTIFICATES_SECRET_LABEL,
-                expire=self._ca_certificate_renewal_threshold,
-            )
+        self._set_juju_secret(
+            label=CA_CERTIFICATES_SECRET_LABEL,
+            content=secret_content,
+            expire=self._ca_certificate_renewal_threshold,
+        )
         logger.info("Root certificates generated and stored.")
 
     def _configure(self, _: EventBase) -> None:
@@ -341,6 +335,7 @@ class SelfSignedCertificatesCharm(CharmBase):
         except SecretNotFoundError:
             self.app.add_secret(content=content, label=label, expire=expire)
 
+    # TODO
     def _root_certificate_matches_config(self) -> bool:
         """Return whether the stored root certificate matches with the config."""
         if not self._config_ca_common_name:

--- a/src/charm.py
+++ b/src/charm.py
@@ -229,7 +229,9 @@ class SelfSignedCertificatesCharm(CharmBase):
             bool: Whether certificates are stored..
         """
         try:
-            self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
+            secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
+            if not secret.get_info().expires:
+                return False
             return True
         except SecretNotFoundError:
             return False
@@ -331,8 +333,9 @@ class SelfSignedCertificatesCharm(CharmBase):
         try:
             secret = self.model.get_secret(label=label)
             secret.set_content(content=content)
-            secret.set_info(expire=expire)
             secret.get_content(refresh=True)
+            new_rev = self.model.get_secret(label=label)
+            new_rev.set_info(expire=expire)
         except SecretNotFoundError:
             self.app.add_secret(content=content, label=label, expire=expire)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -327,7 +327,7 @@ class SelfSignedCertificatesCharm(CharmBase):
         )
 
     def _set_juju_secret(self, label: str, content: dict[str, str], expire: timedelta) -> None:
-        """Set a juju secret."""
+        """Create or update a juju secret."""
         try:
             secret = self.model.get_secret(label=label)
             secret.set_content(content=content)

--- a/src/charm.py
+++ b/src/charm.py
@@ -94,7 +94,9 @@ class SelfSignedCertificatesCharm(CharmBase):
         secret_info = secret.get_info()
         if not secret_info.expires:
             return False
-        return secret_info.expires > datetime.now()
+        if secret_info.expires.tzinfo is None:
+            return secret_info.expires > datetime.now()
+        return secret_info.expires > datetime.now(secret_info.expires.tzinfo)
 
     @property
     def _config_root_ca_certificate_validity(self) -> timedelta:

--- a/src/charm.py
+++ b/src/charm.py
@@ -161,10 +161,10 @@ class SelfSignedCertificatesCharm(CharmBase):
         """Parse a given time string.
 
         It must be a number followed by either an
-        s for seconds, h for hours, d for days or y for years.
+        m for minutes, h for hours, d for days or y for years.
 
         Args:
-            time_str: the input string. Ex: "15s", "365d", "10w"
+            time_str: the input string. Ex: "15m", "365d", "10w"
                 or "10" and will be converted to days
         Returns:
             timedelta object representing the given string
@@ -172,8 +172,8 @@ class SelfSignedCertificatesCharm(CharmBase):
         if time_str.isnumeric():
             return timedelta(days=int(time_str))
         value, unit = int(time_str[:-1]), time_str[-1]
-        if unit == "s":
-            return timedelta(seconds=value)
+        if unit == "m":
+            return timedelta(minutes=value)
         elif unit == "h":
             return timedelta(hours=value)
         elif unit == "d":

--- a/src/charm.py
+++ b/src/charm.py
@@ -263,6 +263,7 @@ class SelfSignedCertificatesCharm(CharmBase):
         if self._root_certificate_is_stored:
             secret = self.model.get_secret(label=CA_CERTIFICATES_SECRET_LABEL)
             secret.set_content(content=secret_content)
+            secret.set_info(expire=self._ca_certificate_renewal_threshold)
             secret.get_content(refresh=True)
         else:
             self.app.add_secret(

--- a/src/charm.py
+++ b/src/charm.py
@@ -165,26 +165,6 @@ class SelfSignedCertificatesCharm(CharmBase):
         results = {"certificates": [certificate.to_json() for certificate in certificates]}
         event.set_results(results)
 
-    def _on_rotate_private_key(self, event: ActionEvent):
-        """Handle the rotate-private-key action.
-
-        Args:
-            event (ActionEvent): Juju event
-        """
-        if not self.unit.is_leader():
-            event.fail("This action can only be run on the leader unit.")
-            return
-        self.tls_certificates.revoke_all_certificates()
-        self._clean_up_juju_secret(EXPIRING_CA_CERTIFICATES_SECRET_LABEL)
-        logger.info("Revoked all previously issued certificates.")
-        try:
-            self._generate_root_certificate()
-        except ValueError as e:
-            logger.error("Failed to rotate private key: %s", e)
-            event.fail(f"Failed to rotate private key, please try again: {e}")
-            return
-        event.set_results({"result": "New private key and CA certificate generated and stored."})
-
     def _parse_config_time_string(self, time_str: str) -> timedelta:
         """Parse a given time string.
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -385,6 +385,7 @@ class SelfSignedCertificatesCharm(CharmBase):
             if certificate.validity_start_time and certificate.expiry_time
             else timedelta(days=0)
         )
+
         return (
             self._config_ca_common_name == certificate.common_name
             and self._config_ca_organization == certificate.organization

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,7 @@
+"""Constants."""
+
+CA_CERTIFICATES_SECRET_LABEL = "active-ca-certificates"
+EXPIRING_CA_CERTIFICATES_SECRET_LABEL = "expiring-ca-certificates"
+CA_CERT_PATH = "/tmp/ca-cert.pem"
+TLS_LIB_PATH = "charms.tls_certificates_interface.v4.tls_certificates"
+SEND_CA_CERT_REL_NAME = "send-ca-cert"  # Must match metadata

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -88,6 +88,7 @@ async def deploy(ops_test: OpsTest, request):
         TLS_REQUIRER_CHARM_NAME,
         application_name=TLS_REQUIRER_CHARM_NAME,
         revision=REQUIRER_CHARM_REVISION_ARM if ARCH == "arm64" else REQUIRER_CHARM_REVISION_AMD,
+        channel="stable",
         constraints={"arch": ARCH},
     )
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -136,7 +136,7 @@ async def test_given_tls_requirer_is_integrated_when_certificate_expires_then_ne
     assert application
     await application.set_config(
         {
-            "root-ca-validity": "60s",
+            "root-ca-validity": "90s",
             "certificate-validity": "30s",
         }
     )
@@ -149,16 +149,17 @@ async def test_given_tls_requirer_is_integrated_when_certificate_expires_then_ne
     action_output = await wait_for_requirer_certificates(
         ops_test=ops_test, ca_common_name=new_common_name
     )
-    old_certificate = action_output.get("ca-certificate", "")
+    old_certificate = action_output.get("certificate", "")
 
     assert old_certificate
 
-    time.sleep(30)
+    # Wait for the certificate to expire
+    time.sleep(35)
 
     action_output = await wait_for_requirer_certificates(
         ops_test=ops_test, ca_common_name=new_common_name
     )
-    new_certificate = action_output.get("ca-certificate", "")
+    new_certificate = action_output.get("certificate", "")
     assert new_certificate
     assert new_certificate != old_certificate
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -24,7 +24,8 @@ TLS_REQUIRER_CHARM_NAME = "tls-certificates-requirer"
 CA_COMMON_NAME = "example.com"
 
 ARCH = "arm64" if platform.machine() == "aarch64" else "amd64"
-
+REQUIRER_CHARM_REVISION_ARM = 103
+REQUIRER_CHARM_REVISION_AMD = 104
 
 async def wait_for_requirer_certificates(ops_test: OpsTest, ca_common_name: str) -> Dict[str, str]:
     """Wait for the certificate to be provided to the `tls-requirer-requirer/0` unit.
@@ -82,10 +83,17 @@ async def deploy(ops_test: OpsTest, request):
         },
         constraints={"arch": ARCH},
     )
+    if ARCH == "arm64":
+         await ops_test.model.deploy(
+        TLS_REQUIRER_CHARM_NAME,
+        application_name=TLS_REQUIRER_CHARM_NAME,
+        revision=REQUIRER_CHARM_REVISION_ARM,
+        constraints={"arch": ARCH},
+    )
     await ops_test.model.deploy(
         TLS_REQUIRER_CHARM_NAME,
         application_name=TLS_REQUIRER_CHARM_NAME,
-        channel="latest/edge",
+        revision=REQUIRER_CHARM_REVISION_AMD,
         constraints={"arch": ARCH},
     )
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -27,6 +27,7 @@ ARCH = "arm64" if platform.machine() == "aarch64" else "amd64"
 REQUIRER_CHARM_REVISION_ARM = 103
 REQUIRER_CHARM_REVISION_AMD = 104
 
+
 async def wait_for_requirer_certificates(ops_test: OpsTest, ca_common_name: str) -> Dict[str, str]:
     """Wait for the certificate to be provided to the `tls-requirer-requirer/0` unit.
 
@@ -83,17 +84,10 @@ async def deploy(ops_test: OpsTest, request):
         },
         constraints={"arch": ARCH},
     )
-    if ARCH == "arm64":
-         await ops_test.model.deploy(
-        TLS_REQUIRER_CHARM_NAME,
-        application_name=TLS_REQUIRER_CHARM_NAME,
-        revision=REQUIRER_CHARM_REVISION_ARM,
-        constraints={"arch": ARCH},
-    )
     await ops_test.model.deploy(
         TLS_REQUIRER_CHARM_NAME,
         application_name=TLS_REQUIRER_CHARM_NAME,
-        revision=REQUIRER_CHARM_REVISION_AMD,
+        revision=REQUIRER_CHARM_REVISION_ARM if ARCH == "arm64" else REQUIRER_CHARM_REVISION_AMD,
         constraints={"arch": ARCH},
     )
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -60,8 +60,8 @@ async def deploy(ops_test: OpsTest, request):
         trust=True,
         config={
             "ca-common-name": CA_COMMON_NAME,
-            "root-ca-validity": 200,
-            "certificate-validity": 100,
+            "root-ca-validity": "200",
+            "certificate-validity": "100",
             "ca-email-address": "test@example.com",
             "ca-country-name": "US",
             "ca-state-or-province-name": "California",
@@ -136,9 +136,8 @@ async def test_given_tls_requirer_is_integrated_when_certificate_expires_then_ne
     assert application
     await application.set_config(
         {
-            "root-ca-validity": 60,
-            "certificate-validity": 30,
-            "validity-unit": "seconds",
+            "root-ca-validity": "60s",
+            "certificate-validity": "30s",
         }
     )
     await ops_test.model.wait_for_idle(

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -44,10 +44,12 @@ class TestCharmCollectStatus:
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state=state_in)
 
         assert state_out.unit_status == BlockedStatus(
-            "The following configuration values are not valid: ['certificate-validity', 'root-ca-validity']"
+            "The following configuration values are not valid: ['certificate-validity', 'root-ca-validity']"  # noqa: E501
         )
 
-    def test_given_invalid_root_ca_validity_config_when_collect_unit_status_then_status_is_blocked(self):
+    def test_given_root_ca_validity_config_not_twice_the_certificate_validity_when_collect_unit_status_then_status_is_blocked(  # noqa: E501
+        self,
+    ):
         state_in = scenario.State(
             config={
                 "ca-common-name": "pizza.example.com",
@@ -60,7 +62,7 @@ class TestCharmCollectStatus:
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state=state_in)
 
         assert state_out.unit_status == BlockedStatus(
-            "The following configuration values are not valid: ['certificate-validity', 'root-ca-validity']"
+            "The following configuration values are not valid: ['certificate-validity', 'root-ca-validity']"  # noqa: E501
         )
 
     @patch("charm.generate_private_key")

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -44,7 +44,23 @@ class TestCharmCollectStatus:
         state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state=state_in)
 
         assert state_out.unit_status == BlockedStatus(
-            "The following configuration values are not valid: ['certificate-validity']"
+            "The following configuration values are not valid: ['certificate-validity', 'root-ca-validity']"
+        )
+
+    def test_given_invalid_root_ca_validity_config_when_collect_unit_status_then_status_is_blocked(self):
+        state_in = scenario.State(
+            config={
+                "ca-common-name": "pizza.example.com",
+                "certificate-validity": 100,
+                "root-ca-validity": 0,
+            },
+            leader=True,
+        )
+
+        state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state=state_in)
+
+        assert state_out.unit_status == BlockedStatus(
+            "The following configuration values are not valid: ['certificate-validity', 'root-ca-validity']"
         )
 
     @patch("charm.generate_private_key")

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -21,7 +21,7 @@ class TestCharmCollectStatus:
         state_in = scenario.State(
             config={
                 "ca-common-name": "",
-                "certificate-validity": 100,
+                "certificate-validity": "100",
             },
             leader=True,
         )
@@ -36,7 +36,7 @@ class TestCharmCollectStatus:
         state_in = scenario.State(
             config={
                 "ca-common-name": "pizza.example.com",
-                "certificate-validity": 0,
+                "certificate-validity": "0",
             },
             leader=True,
         )
@@ -53,8 +53,8 @@ class TestCharmCollectStatus:
         state_in = scenario.State(
             config={
                 "ca-common-name": "pizza.example.com",
-                "certificate-validity": 100,
-                "root-ca-validity": 0,
+                "certificate-validity": "100",
+                "root-ca-validity": "0",
             },
             leader=True,
         )
@@ -77,7 +77,7 @@ class TestCharmCollectStatus:
         state_in = scenario.State(
             config={
                 "ca-common-name": "pizza.example.com",
-                "certificate-validity": 100,
+                "certificate-validity": "100",
             },
             leader=True,
         )

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -193,12 +193,12 @@ class TestCharmConfigure:
         initial_ca_certificate = generate_ca(
             private_key=initial_ca_private_key,
             common_name="example.com",
-            validity=timedelta(seconds=60),
+            validity=timedelta(minutes=2),
         )
         new_ca_certificate = generate_ca(
             private_key=new_ca_private_key,
             common_name="example.com",
-            validity=timedelta(seconds=60),
+            validity=timedelta(minutes=2),
         )
         patch_generate_ca.return_value = new_ca_certificate
         patch_generate_private_key.return_value = new_ca_private_key
@@ -214,8 +214,8 @@ class TestCharmConfigure:
         state_in = scenario.State(
             config={
                 "ca-common-name": "example.com",
-                "root-ca-validity": "60s",
-                "certificate-validity": "30s",
+                "root-ca-validity": "2m",
+                "certificate-validity": "1m",
             },
             leader=True,
             secrets={ca_certificate_secret},
@@ -239,7 +239,7 @@ class TestCharmConfigure:
         assert expiring_ca_certificates_secret.expire
         tolerance = timedelta(seconds=1)
         assert (
-            abs(expiring_ca_certificates_secret.expire - (datetime.now() + timedelta(seconds=30)))
+            abs(expiring_ca_certificates_secret.expire - (datetime.now() + timedelta(minutes=1)))
             <= tolerance
         )
 

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -50,8 +50,8 @@ class TestCharmConfigure:
         state_in = scenario.State(
             config={
                 "ca-common-name": "pizza.example.com",
-                "certificate-validity": 100,
-                "root-ca-validity": 200,
+                "certificate-validity": "100",
+                "root-ca-validity": "200",
             },
             leader=True,
         )
@@ -77,8 +77,8 @@ class TestCharmConfigure:
         state_in = scenario.State(
             config={
                 "ca-common-name": "pizza.example.com",
-                "certificate-validity": certificate_validity,
-                "root-ca-validity": root_ca_validity,
+                "certificate-validity": str(certificate_validity),
+                "root-ca-validity": str(root_ca_validity),
             },
             leader=True,
         )
@@ -111,7 +111,7 @@ class TestCharmConfigure:
         state_in = scenario.State(
             config={
                 "ca-common-name": "pizza.example.com",
-                "certificate-validity": 100,
+                "certificate-validity": "100",
             },
             leader=True,
             secrets=frozenset(),
@@ -156,8 +156,8 @@ class TestCharmConfigure:
                 "ca-email-address": "abc@example.com",
                 "ca-country-name": "CA",
                 "ca-locality-name": "Montreal",
-                "certificate-validity": 100,
-                "root-ca-validity": 200,
+                "certificate-validity": "100",
+                "root-ca-validity": "200",
             },
             leader=True,
             secrets={ca_certificate_secret},
@@ -214,9 +214,8 @@ class TestCharmConfigure:
         state_in = scenario.State(
             config={
                 "ca-common-name": "example.com",
-                "root-ca-validity": 60,
-                "certificate-validity": 30,
-                "validity-unit": "seconds",
+                "root-ca-validity": "60s",
+                "certificate-validity": "30s",
             },
             leader=True,
             secrets={ca_certificate_secret},
@@ -291,8 +290,8 @@ class TestCharmConfigure:
         state_in = scenario.State(
             config={
                 "ca-common-name": "example.com",
-                "certificate-validity": 100,
-                "root-ca-validity": 200,
+                "certificate-validity": "100",
+                "root-ca-validity": "200",
             },
             leader=True,
             relations={tls_relation},
@@ -337,7 +336,7 @@ class TestCharmConfigure:
         state_in = scenario.State(
             config={
                 "ca-common-name": "pizza.example.com",
-                "certificate-validity": 100,
+                "certificate-validity": "100",
             },
             leader=True,
             secrets={ca_certificates_secret},
@@ -389,7 +388,7 @@ class TestCharmConfigure:
         state_in = scenario.State(
             config={
                 "ca-common-name": "common-name-new.example.com",
-                "certificate-validity": 100,
+                "certificate-validity": "100",
             },
             leader=True,
             secrets={ca_certificates_secret},
@@ -434,8 +433,8 @@ class TestCharmConfigure:
             leader=True,
             config={
                 "ca-common-name": "example.com",
-                "certificate-validity": 100,
-                "root-ca-validity": 200,
+                "certificate-validity": "100",
+                "root-ca-validity": "200",
             },
         )
 

--- a/tests/unit/test_charm_get_ca_certificate.py
+++ b/tests/unit/test_charm_get_ca_certificate.py
@@ -2,6 +2,8 @@
 # See LICENSE file for licensing details.
 
 
+from datetime import datetime, timedelta
+
 import pytest
 import scenario
 
@@ -23,8 +25,9 @@ class TestCharmGetCACertificate:
             {
                 "ca-certificate": ca_certificate,
             },
-            label="ca-certificates",
+            label="active-ca-certificates",
             owner="app",
+            expire=datetime.now() + timedelta(days=100),
         )
         state_in = scenario.State(
             leader=True,

--- a/tests/unit/test_charm_get_issued_certificates.py
+++ b/tests/unit/test_charm_get_issued_certificates.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 import json
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
@@ -45,7 +46,7 @@ class TestCharmGetIssuedCertificates:
         ca_certificate = generate_ca(
             private_key=ca_private_key,
             common_name="example.com",
-            validity=100,
+            validity=timedelta(days=100),
         )
         requirer_private_key = generate_private_key()
         csr = generate_csr(private_key=requirer_private_key, common_name="example.com")
@@ -53,7 +54,7 @@ class TestCharmGetIssuedCertificates:
             csr=csr,
             ca=ca_certificate,
             ca_private_key=ca_private_key,
-            validity=100,
+            validity=timedelta(days=100),
         )
         chain = [ca_certificate, certificate]
         revoked = False

--- a/tests/unit/test_charm_get_issued_certificates.py
+++ b/tests/unit/test_charm_get_issued_certificates.py
@@ -71,7 +71,7 @@ class TestCharmGetIssuedCertificates:
         state_in = scenario.State(
             config={
                 "ca-common-name": "example.com",
-                "certificate-validity": 100,
+                "certificate-validity": "100",
             },
             leader=True,
         )


### PR DESCRIPTION
# Description

Fixes #238, #239 and #241 

- This PR implements the renewal of the CA certificate
- It handles CA certificate configuration option changes
- It keeps track of two CA certificates, one active and one expiring CA certificate.
- Improves validity time configs to allow units, inspired by #236 @kayra1 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
