### PR TITLE
chore: Fix CI flakiness by rolling back concierge and preventing pytest-asyncio updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,6 +25,12 @@
       "groupName": "Python dependencies"
     },
     {
+      // Bumping "pytest-asyncio" over 0.23 breaks the integration tests
+      "matchPackageNames": ["pytest-asyncio"],
+      "matchUpdateTypes": ["minor"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["github-actions"],
       "groupName": "GitHub actions"
     },

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup LXD
         uses: canonical/setup-lxd@main
         with:
-            channel: 5.20/stable
+            channel: 5.21/stable
     
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -28,9 +28,17 @@ jobs:
         run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
       
       - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          juju-channel: 3.5/stable
+          provider: microk8s
+          channel: 1.31-strict/stable
+          lxd-channel: 5.21/stable
+
+      - name: Install UV and Tox
         run: |
-          sudo snap install concierge --classic
-          sudo concierge prepare -p microk8s --microk8s-channel "1.29-strict/stable" --juju-channel "3.4/stable" --lxd-channel "5.20/stable" --extra-snaps astral-uv/latest/stable
+          python3 -m pip uninstall tox -y
+          sudo snap install astral-uv --classic
           uv tool install tox --with tox-uv
 
       - name: Run integration tests


### PR DESCRIPTION
# Description

Rollback concierge introduction to fix CI flakiness. Also prevent renovate from updating pytest-asyncio as it breaks integration tests.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
