### PR TITLE
chore: support multiple charm bases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         arch:
           - arch: amd64
-            runner: ubuntu-22.04
+            runner: ubuntu-24.04
           - arch: arm64
             runner: [self-hosted, linux, ARM64, medium, jammy]
     runs-on: ${{ matrix.arch.runner }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,9 +17,6 @@ jobs:
           - arch: arm64
             base: ubuntu-22.04
             runner: [self-hosted, linux, ARM64, medium, jammy]
-          - arch: arm64
-            base: ubuntu-24.04
-            runner: [self-hosted, linux, ARM64, medium, noble]
     runs-on: ${{ matrix.version.runner }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,9 +9,17 @@ jobs:
       matrix:
         arch:
           - arch: amd64
+            base: ubuntu-22.04
+            runner: ubuntu-22.04
+          - arch: amd64
+            base: ubuntu-24.04
             runner: ubuntu-24.04
           - arch: arm64
+            base: ubuntu-22.04
             runner: [self-hosted, linux, ARM64, medium, jammy]
+          - arch: arm64
+            base: ubuntu-24.04
+            runner: [self-hosted, linux, ARM64, medium, noble]
     runs-on: ${{ matrix.arch.runner }}
     steps:
       - uses: actions/checkout@v4
@@ -23,6 +31,14 @@ jobs:
     
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic
+      
+      - name: Use base specific charmcraft.yaml
+        run: |
+          # Only copy the base specific charmcraft_<base>.yaml if it is not the
+          # latest LTS (24.04). The latest LTS is used in the bare charmcraft.yaml
+          if [ "${{ matrix.arch.base }}" != "ubuntu-24.04" ]; then
+              cp charmcraft_${{ matrix.arch.base }}.yaml charmcraft.yaml
+          fi
 
       - name: Build charm under test
         run: charmcraft pack --verbose

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ jobs:
   build-charm-under-test:
     strategy:
       matrix:
-        arch:
+        version:
           - arch: amd64
             base: ubuntu-22.04
             runner: ubuntu-22.04
@@ -20,7 +20,7 @@ jobs:
           - arch: arm64
             base: ubuntu-24.04
             runner: [self-hosted, linux, ARM64, medium, noble]
-    runs-on: ${{ matrix.arch.runner }}
+    runs-on: ${{ matrix.version.runner }}
     steps:
       - uses: actions/checkout@v4
     
@@ -36,8 +36,8 @@ jobs:
         run: |
           # Only copy the base specific charmcraft_<base>.yaml if it is not the
           # latest LTS (24.04). The latest LTS is used in the bare charmcraft.yaml
-          if [ "${{ matrix.arch.base }}" != "ubuntu-24.04" ]; then
-              cp charmcraft_${{ matrix.arch.base }}.yaml charmcraft.yaml
+          if [ "${{ matrix.version.base }}" != "ubuntu-24.04" ]; then
+              cp charmcraft_${{ matrix.version.base }}.yaml charmcraft.yaml
           fi
 
       - name: Build charm under test
@@ -46,6 +46,6 @@ jobs:
       - name: Archive Charm Under Test
         uses: actions/upload-artifact@v4
         with:
-          name: built-charm-${{ matrix.arch.arch }}
+          name: built-charm-${{ matrix.version.arch }}-${{ matrix.version.base }}
           path: "*.charm"
           retention-days: 5

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         arch:
           - arch: amd64
-            runner: ubuntu-22.04
+            runner: ubuntu-24.04
           - arch: arm64
             runner: [self-hosted, linux, ARM64, medium, jammy]
     runs-on: ${{ matrix.arch.runner }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -10,8 +10,12 @@ jobs:
         arch:
           - arch: amd64
             runner: ubuntu-24.04
+          - arch: amd64
+            runner: ubuntu-24.04
           - arch: arm64
             runner: [self-hosted, linux, ARM64, medium, jammy]
+          - arch: arm64
+            runner: [self-hosted, linux, ARM64, medium, noble]
     runs-on: ${{ matrix.arch.runner }}
     steps:
       - name: Checkout

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -7,16 +7,20 @@ jobs:
   integration-test:
     strategy:
       matrix:
-        arch:
+        version:
           - arch: amd64
-            runner: ubuntu-24.04
+            base: ubuntu-22.04
+            runner: ubuntu-22.04
           - arch: amd64
+            base: ubuntu-24.04
             runner: ubuntu-24.04
           - arch: arm64
+            base: ubuntu-22.04
             runner: [self-hosted, linux, ARM64, medium, jammy]
           - arch: arm64
+            base: ubuntu-24.04
             runner: [self-hosted, linux, ARM64, medium, noble]
-    runs-on: ${{ matrix.arch.runner }}
+    runs-on: ${{ matrix.version.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,7 +28,7 @@ jobs:
       - name: Fetch Charm Under Test
         uses: actions/download-artifact@v4
         with:
-          name: built-charm-${{ matrix.arch.arch }}
+          name: built-charm-${{ matrix.version.arch }}-${{ matrix.version.base }}
           path: built/
       
       - name: Get Charm Under Test Path

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -17,9 +17,6 @@ jobs:
           - arch: arm64
             base: ubuntu-22.04
             runner: [self-hosted, linux, ARM64, medium, jammy]
-          - arch: arm64
-            base: ubuntu-24.04
-            runner: [self-hosted, linux, ARM64, medium, noble]
     runs-on: ${{ matrix.version.runner }}
     steps:
       - name: Checkout

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -46,5 +46,5 @@ jobs:
           destination-channel: latest/${{ env.promote-to }}
           origin-channel: latest/${{ env.promote-from }}
           charmcraft-channel: latest/stable
-          base-channel: "22.04"
+          base-channel: "24.04"
           base-architecture: ${{ github.event.inputs.arch }}

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         arch:
           - arch: amd64
-            runner: ubuntu-22.04
+            runner: ubuntu-24.04
           - arch: arm64
             runner: [self-hosted, linux, ARM64, medium, jammy]
     runs-on: ${{ matrix.arch.runner }}

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -10,12 +10,20 @@ jobs:
   publish-charm:
     strategy:
       matrix:
-        arch:
+        version:
           - arch: amd64
+            base: ubuntu-22.04
+            runner: ubuntu-22.04
+          - arch: amd64
+            base: ubuntu-24.04
             runner: ubuntu-24.04
           - arch: arm64
+            base: ubuntu-22.04
             runner: [self-hosted, linux, ARM64, medium, jammy]
-    runs-on: ${{ matrix.arch.runner }}
+          - arch: arm64
+            base: ubuntu-24.04
+            runner: [self-hosted, linux, ARM64, medium, noble]
+    runs-on: ${{ matrix.version.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,7 +34,7 @@ jobs:
       - name: Fetch Tested Charm
         uses: actions/download-artifact@v4
         with:
-          name: built-charm-${{ matrix.arch.arch }}
+          name: built-charm-${{ matrix.version.arch }}-${{ matrix.version.base }}
       
       - name: Get Charm Under Test Path
         id: charm-path

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -20,9 +20,6 @@ jobs:
           - arch: arm64
             base: ubuntu-22.04
             runner: [self-hosted, linux, ARM64, medium, jammy]
-          - arch: arm64
-            base: ubuntu-24.04
-            runner: [self-hosted, linux, ARM64, medium, noble]
     runs-on: ${{ matrix.version.runner }}
     steps:
       - name: Checkout

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -27,27 +27,11 @@ assumes:
   - juju >= 3.1
 
 type: charm
-bases:
-  - build-on:
-    - name: ubuntu
-      channel: "24.04"
-      architectures:
-        - amd64
-    run-on:
-    - name: ubuntu
-      channel: "24.04"
-      architectures:
-        - amd64
-  - build-on:
-    - name: ubuntu
-      channel: "24.04"
-      architectures:
-        - arm64
-    run-on:
-    - name: ubuntu
-      channel: "24.04"
-      architectures:
-        - arm64
+base: ubuntu@24.04
+build-base: ubuntu@24.04
+platforms:
+  amd64:
+  arm64:
 
 parts:
   charm:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -30,22 +30,22 @@ type: charm
 bases:
   - build-on:
     - name: ubuntu
-      channel: "22.04"
+      channel: "24.04"
       architectures:
         - amd64
     run-on:
     - name: ubuntu
-      channel: "22.04"
+      channel: "24.04"
       architectures:
         - amd64
   - build-on:
     - name: ubuntu
-      channel: "22.04"
+      channel: "24.04"
       architectures:
         - arm64
     run-on:
     - name: ubuntu
-      channel: "22.04"
+      channel: "24.04"
       architectures:
         - arm64
 

--- a/charmcraft_ubuntu-22.04.yaml
+++ b/charmcraft_ubuntu-22.04.yaml
@@ -1,0 +1,151 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: self-signed-certificates
+
+summary: An operator to provide self-signed X.509 certificates to your charms.
+
+description: |
+  An operator to provide self-signed X.509 certificates to your charms.
+
+  This charm relies on the `tls-certificates` charm relation interface. When a requirer charm
+  inserts a Certificate Signing Request in its unit databag, the
+  `self-signed-certificates-operator` will read it, generate a self-signed X.509 certificates and
+  inserts this certificate back into the relation data.
+
+  This charm is useful when developing charms or when deploying charms in non-production environment.
+links:
+  documentation: https://discourse.charmhub.io/t/self-signed-x-509-certificates-documentation/11591
+  website:
+    - https://charmhub.io/self-signed-certificates
+  source:
+    - https://github.com/canonical/self-signed-certificates-operator
+  issues:
+    - https://github.com/canonical/self-signed-certificates-operator/issues
+
+assumes:
+  - juju >= 3.1
+
+type: charm
+base: ubuntu@22.04
+build-base: ubuntu@22.04
+platforms:
+  amd64:
+  arm64:
+
+parts:
+  charm:
+    source: .
+    plugin: charm
+    charm-requirements:
+      - requirements.txt
+    build-packages:
+      - libffi-dev
+      - libssl-dev
+      - pkg-config
+    build-snaps:
+      - astral-uv
+      - rustup
+    override-build: |
+      rustup default stable
+      uv export --frozen --no-dev -o requirements.txt
+      craftctl default
+
+provides:
+  certificates:
+    interface: tls-certificates
+  send-ca-cert:
+    interface: certificate_transfer
+    description: |
+      Send our CA certificate so clients can trust the CA by means of forming a relation.
+
+requires:
+  tracing:
+    interface: tracing
+    limit: 1
+
+config:
+  options:
+    ca-common-name:
+      type: string
+      default: self-signed-certificates-operator
+      description: >
+        Common name to be used by the Certificate Authority.
+        Changing this value will trigger generation of a new CA certificate,
+        revoking all previously issued certificates.
+    ca-organization:
+      type: string
+      description: >
+        Organization name to be used by the Certificate Authority.
+        Changing this value will trigger generation of a new CA certificate,
+        revoking all previously issued certificates.
+    ca-organizational-unit:
+      type: string
+      description: >
+        Organizational unit to be used by the Certificate Authority.
+        Changing this value will trigger generation of a new CA certificate,
+        revoking all previously issued certificates.
+    ca-email-address:
+      type: string
+      description: >
+        Email address to be used by the Certificate Authority.
+        Changing this value will trigger generation of a new CA certificate,
+        revoking all previously issued certificates.
+    ca-country-name:
+      type: string
+      description: >
+        Country name to be used by the Certificate Authority.
+        Changing this value will trigger generation of a new CA certificate,
+        revoking all previously issued certificates.
+    ca-state-or-province-name:
+      type: string
+      description: >
+        State or province name to be used by the Certificate Authority.
+        Changing this value will trigger generation of a new CA certificate,
+        revoking all previously issued certificates.
+    ca-locality-name:
+      type: string
+      description: >
+        Locality name to be used by the Certificate Authority.
+        Changing this value will trigger generation of a new CA certificate,
+        revoking all previously issued certificates.
+    root-ca-validity:
+      type: string
+      default: 365d
+      description: >
+        RootCA certificate validity. 
+        The given value must be followed by one of: "m" for minutes, "h" for hours, "d" for days and "w" for weeks. 
+        For example, "1m" for 1 minute, "10w" for 10 weeks.
+        If no units are given, the unit will be assumed as days.
+        Defaults to 365 days.
+        This value should be equal to or longer than twice the certificate-validity.
+        Changing this value will trigger generation of a new CA certificate,
+        revoking all previously issued certificates.
+    certificate-validity:
+      type: string
+      default: 90d
+      description: > 
+        Signed certificate validity.
+        The given value must be followed by one of: "m" for minutes, "h" for hours, "d" for days and "w" for weeks. 
+        For example, "1m" for 1 minute, "10w" for 10 weeks.
+        If no units are given, the unit will be assumed as days.
+        Defaults to 90 days.
+        This value should be equal to or shorter than half the root-ca-validity.
+        Changing this value will trigger generation of a new CA certificate,
+        revoking all previously issued certificates.
+    certificate-limit:
+      type: int
+      default: 99
+      description: >
+        Maximum number of certificates that can be issued to a single requirer.
+        Use -1 for allowing an unlimited number of certificates.
+
+actions:
+  get-ca-certificate:
+    description: Outputs the CA cert.
+
+  get-issued-certificates:
+    description: Outputs the certificates issued by the charm.
+
+  rotate-private-key:
+    description: Creates a new private key and a new CA certificate and revokes all issued certificates.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,7 +8,7 @@ resource "juju_application" "self-signed-certificates" {
   charm {
     name    = "self-signed-certificates"
     channel = var.channel
-    base    = "ubuntu@22.04"
+    base    = "ubuntu@24.04"
   }
   config = var.config
   units  = 1


### PR DESCRIPTION
# Description

We add support for building, running integration tests, and publishing for multiple charm bases. For now, we will support `ubuntu@22.04` and `ubuntu@24.04`.

Fixes #270 

## This is a temporary solution

This solution is aimed at supporting the Openstack team in releasing sunbeam by christmas. In the longer run, we'll want to leverage the (not yet existing) multi base support in charmcraft.

## Why aren't we building for ubuntu@24.04 on arm?

There is an issue when installing tox on Ubuntu24.04 on the arm runner: 

```
error: externally-managed-environment
  
  × This environment is externally managed
  ╰─> To install Python packages system-wide, try apt install
      python3-xyz, where xyz is the package you are trying to
      install.
      
      If you wish to install a non-Debian-packaged Python package,
      create a virtual environment using python3 -m venv path/to/venv.
      Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
      sure you have python3-full installed.
      
      If you wish to install a non-Debian packaged Python application,
      it may be easiest to use pipx install xyz, which will manage a
      virtual environment for you. Make sure you have pipx installed.
      
      See /usr/share/doc/python3.12/README.venv for more information.
  
  note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
  hint: See PEP 668 for the detailed specification.
```

Arm support is a nice to have (that nobody uses for the time being) and solving this issue can be done at a different time.

## Rationale

As of the latest charmcraft version, we can only specify 1 base per `charmcraft.yaml` file. 

Reference:
- https://juju.is/docs/sdk/charmcraft-yaml#heading--bases
- https://github.com/canonical/charmcraft/issues/2008
- https://docs.google.com/document/d/1QVHxZumruKVZ3yJ2C74qWhvs-ye5I9S6avMBDHs2YcQ/edit?tab=t.0
- https://juju.is/docs/sdk/charmcraft-yaml#heading--bases

## Other alternatives

We could have gone with other alternatives like different charm folders, branches, or scripts. I found this approach here (2 different charmcraft.yaml) files to be the simplest.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
