### PR TITLE
refactor: Use `ops.main` instead of `ops.main.main`, the latter is deprecated

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -25,9 +25,9 @@ from charms.tls_certificates_interface.v4.tls_certificates import (
     generate_certificate,
     generate_private_key,
 )
+from ops import main
 from ops.charm import ActionEvent, CharmBase, CollectStatusEvent
 from ops.framework import EventBase
-from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, SecretNotFoundError
 
 from constants import (


### PR DESCRIPTION
This should remove the following deprecation warning:

```
unit-self-signed-certificates-0: 15:23:29 WARNING unit.self-signed-certificates/0.update-status /var/lib/juju/agents/unit-self-signed-certificates-0/charm/./src/charm.py:525: DeprecationWarning: Calling `ops.main.main()` is deprecated, call `ops.main()` instead
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
