### PR TITLE
build: Enable pyright to check if type hints are missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,4 @@ skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
 
 [tool.pyright]
 include = ["src/**.py"]
+reportMissingParameterType = true

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,7 +7,7 @@
 import logging
 import typing
 from datetime import datetime, timedelta
-from typing import Iterator, Optional, cast
+from typing import Any, Iterator, Optional, cast
 
 from charms.certificate_transfer_interface.v0.certificate_transfer import (
     CertificateTransferProvides,
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 class SelfSignedCertificatesCharm(CharmBase):
     """Main class to handle Juju events."""
 
-    def __init__(self, *args):
+    def __init__(self, *args: Any):
         """Observe config change and certificate request events."""
         super().__init__(*args)
         self.tls_certificates = TLSCertificatesProvidesV4(self, "certificates")
@@ -515,7 +515,7 @@ class SelfSignedCertificatesCharm(CharmBase):
         ca_certificate_secret_content = ca_certificate_secret.get_content(refresh=True)
         event.set_results({"ca-certificate": ca_certificate_secret_content["ca-certificate"]})
 
-    def _send_ca_cert(self, *, rel_id=None):
+    def _send_ca_cert(self, *, rel_id: Optional[int] = None):
         """There is one (and only one) CA cert that we need to forward to multiple apps.
 
         Args:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -60,10 +60,10 @@ async def wait_for_requirer_certificates(ops_test: OpsTest, ca_common_name: str)
 
 @pytest.fixture(scope="module")
 @pytest.mark.abort_on_fail
-async def deploy(ops_test: OpsTest, request):
+async def deploy(ops_test: OpsTest, request: pytest.FixtureRequest) -> None:
     """Build the charm-under-test and deploy it."""
     assert ops_test.model
-    charm = Path(request.config.getoption("--charm_path")).resolve()
+    charm = Path(str(request.config.getoption("--charm_path"))).resolve()
     logger.info("Deploying charms for architecture: %s", ARCH)
     await ops_test.model.set_constraints({"arch": ARCH})
     await ops_test.model.deploy(
@@ -96,7 +96,7 @@ async def deploy(ops_test: OpsTest, request):
 @pytest.mark.abort_on_fail
 async def test_given_charm_is_built_when_deployed_then_status_is_active(
     ops_test: OpsTest,
-    deploy,
+    deploy: None,
 ):
     assert ops_test.model
     await ops_test.model.wait_for_idle(
@@ -108,7 +108,7 @@ async def test_given_charm_is_built_when_deployed_then_status_is_active(
 
 async def test_given_tls_requirer_is_deployed_when_integrated_then_certificate_is_provided(
     ops_test: OpsTest,
-    deploy,
+    deploy: None,
 ):
     assert ops_test.model
     await ops_test.model.integrate(
@@ -124,7 +124,7 @@ async def test_given_tls_requirer_is_deployed_when_integrated_then_certificate_i
 
 async def test_given_tls_requirer_is_integrated_when_ca_common_name_config_changed_then_new_certificate_is_provided(  # noqa: E501
     ops_test: OpsTest,
-    deploy,
+    deploy: None,
 ):
     new_common_name = "newexample.org"
     assert ops_test.model
@@ -142,7 +142,7 @@ async def test_given_tls_requirer_is_integrated_when_ca_common_name_config_chang
 
 async def test_given_tls_requirer_is_integrated_when_certificates_expires_then_new_certificate_is_provided(  # noqa: E501
     ops_test: OpsTest,
-    deploy,
+    deploy: None,
 ):
     new_common_name = "newexample.org"
     assert ops_test.model
@@ -193,7 +193,7 @@ async def test_given_tls_requirer_is_integrated_when_certificates_expires_then_n
 
 async def test_given_charm_scaled_then_charm_does_not_crash(
     ops_test: OpsTest,
-    deploy,
+    deploy: None,
 ):
     assert ops_test.model
     await ops_test.model.applications[APP_NAME].scale(2)  # type: ignore
@@ -202,7 +202,7 @@ async def test_given_charm_scaled_then_charm_does_not_crash(
     await ops_test.model.wait_for_idle(apps=[APP_NAME], timeout=1000, wait_for_exact_units=1)
 
 
-async def run_get_certificate_action(ops_test) -> Dict[str, str]:
+async def run_get_certificate_action(ops_test: OpsTest) -> Dict[str, str]:
     """Run `get-certificate` on the `tls-requirer-requirer/0` unit.
 
     Args:

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import scenario
@@ -69,11 +69,11 @@ class TestCharmCollectStatus:
     @patch("charm.generate_ca")
     def test_given_valid_config_when_collect_unit_status_then_status_is_active(
         self,
-        patch_generate_ca,
-        patch_generate_private_key,
+        mock_generate_ca: MagicMock,
+        mock_generate_private_key: MagicMock,
     ):
-        patch_generate_ca.return_value = "whatever CA certificate"
-        patch_generate_private_key.return_value = "whatever private key"
+        mock_generate_ca.return_value = "whatever CA certificate"
+        mock_generate_private_key.return_value = "whatever private key"
         state_in = scenario.State(
             config={
                 "ca-common-name": "pizza.example.com",

--- a/tests/unit/test_charm_get_issued_certificates.py
+++ b/tests/unit/test_charm_get_issued_certificates.py
@@ -3,7 +3,7 @@
 
 import json
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import scenario
@@ -40,7 +40,7 @@ class TestCharmGetIssuedCertificates:
     @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV4.get_issued_certificates")
     def test_given_certificates_issued_when_get_issued_certificates_action_then_action_returns_certificates(  # noqa: E501
         self,
-        patch_get_issued_certificates,
+        mock_get_issued_certificates: MagicMock,
     ):
         ca_private_key = generate_private_key()
         ca_certificate = generate_ca(
@@ -58,7 +58,7 @@ class TestCharmGetIssuedCertificates:
         )
         chain = [ca_certificate, certificate]
         revoked = False
-        patch_get_issued_certificates.return_value = [
+        mock_get_issued_certificates.return_value = [
             ProviderCertificate(
                 relation_id=1,
                 certificate_signing_request=csr,

--- a/tests/unit/test_charm_rotate_private_key.py
+++ b/tests/unit/test_charm_rotate_private_key.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import scenario
@@ -31,7 +31,7 @@ class TestCharmRotatePrivateKey:
     @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV4.revoke_all_certificates")
     def test_given_rotate_private_key_action_when_certificates_revoked_and_root_certificate_generated_then_action_succeeds(  # noqa: E501
         self,
-        patch_revoke_all_certificates,
+        patch_revoke_all_certificates: MagicMock,
     ):
         state_in = scenario.State(
             leader=True,
@@ -46,7 +46,7 @@ class TestCharmRotatePrivateKey:
     @patch(f"{TLS_LIB_PATH}.TLSCertificatesProvidesV4.revoke_all_certificates")
     def test_given_rotate_private_key_action_when_config_is_invalid_then_action_fails(  # noqa: E501
         self,
-        patch_revoke_all_certificates,
+        mock_revoke_all_certificates: MagicMock,
     ):
         state_in = scenario.State(
             leader=True,


### PR DESCRIPTION
This change adds a pyright check to ensure that we add type hints to our code