### PR TITLE
fix: Use uv sync in tox to use locked versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+runner = uv-venv-lock-runner
+with_dev = true
 set_env =
     PYTHONPATH = {tox_root}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=pdb.set_trace


### PR DESCRIPTION
Use uv sync in tox to use locked versions. This ensures that tox will not install newer packages when running.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
