### PR TITLE
fix: Use multiarch publish workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,6 +43,8 @@ jobs:
       - unit-tests-with-coverage
       - integration-test
     if: ${{ github.ref_name == 'main' }}
-    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm.yaml@v0
+    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm-multiarch.yaml@v0
+    with:
+      track-name: latest
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # self-signed-certificates-operator
+![CI Status](https://github.com/canonical/self-signed-certificates-operator/actions/workflows/main.yaml/badge.svg)
 [![CharmHub Badge](https://charmhub.io/self-signed-certificates/badge.svg)](https://charmhub.io/self-signed-certificates)
 
 An operator to provide self-signed X.509 certificates to your charms.


### PR DESCRIPTION
# Description

This charms builds for multiple architectures so we need to also publish for multiple architectures.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
