### PR TITLE
feat: support ubuntu@24.04

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,26 +10,34 @@ jobs:
         arch:
           - arch: amd64
             runner: ubuntu-22.04
+            platform: ubuntu@22.04:amd64
           - arch: arm64
             runner: [self-hosted, linux, ARM64, medium, jammy]
+            platform: ubuntu@22.04:arm64
+          - arch: amd64
+            runner: ubuntu-24.04
+            platform: ubuntu@24.04:amd64
+          - arch: arm64
+            runner: [self-hosted, linux, ARM64, medium, noble]
+            platform: ubuntu@24.04:arm64
     runs-on: ${{ matrix.arch.runner }}
     steps:
       - uses: actions/checkout@v4
-    
+
       - name: Setup LXD
         uses: canonical/setup-lxd@main
         with:
             channel: 5.21/stable
-    
+
       - name: Install charmcraft
         run: sudo snap install charmcraft --classic
 
       - name: Build charm under test
-        run: charmcraft pack --verbose
+        run: charmcraft pack --verbose --platform ${{ matrix.arch.platform }}
 
       - name: Archive Charm Under Test
         uses: actions/upload-artifact@v4
         with:
-          name: built-charm-${{ matrix.arch.arch }}
+          name: built-charm-${{ matrix.arch.platform }}
           path: "*.charm"
           retention-days: 5

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -10,8 +10,16 @@ jobs:
         arch:
           - arch: amd64
             runner: ubuntu-22.04
+            platform: ubuntu@22.04:amd64
           - arch: arm64
             runner: [self-hosted, linux, ARM64, medium, jammy]
+            platform: ubuntu@22.04:arm64
+          - arch: amd64
+            runner: ubuntu-24.04
+            platform: ubuntu@24.04:amd64
+          - arch: arm64
+            runner: [self-hosted, linux, ARM64, medium, noble]
+            platform: ubuntu@24.04:arm64
     runs-on: ${{ matrix.arch.runner }}
     steps:
       - name: Checkout
@@ -20,7 +28,7 @@ jobs:
       - name: Fetch Charm Under Test
         uses: actions/download-artifact@v4
         with:
-          name: built-charm-${{ matrix.arch.arch }}
+          name: built-charm-${{ matrix.arch.platform }}
           path: built/
 
       - name: Get Charm Under Test Path

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -21,6 +21,11 @@ jobs:
   promote:
     name: Promote Charm
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        base:
+          - 22.04
+          - 24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,5 +51,5 @@ jobs:
           destination-channel: latest/${{ env.promote-to }}
           origin-channel: latest/${{ env.promote-from }}
           charmcraft-channel: latest/stable
-          base-channel: "22.04"
+          base-channel: ${{ matrix.base }}
           base-architecture: ${{ github.event.inputs.arch }}

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -27,27 +27,11 @@ assumes:
   - juju >= 3.1
 
 type: charm
-bases:
-  - build-on:
-    - name: ubuntu
-      channel: "22.04"
-      architectures:
-        - amd64
-    run-on:
-    - name: ubuntu
-      channel: "22.04"
-      architectures:
-        - amd64
-  - build-on:
-    - name: ubuntu
-      channel: "22.04"
-      architectures:
-        - arm64
-    run-on:
-    - name: ubuntu
-      channel: "22.04"
-      architectures:
-        - arm64
+platforms:
+  ubuntu@22.04:amd64:
+  ubuntu@22.04:arm64:
+  ubuntu@24.04:amd64:
+  ubuntu@24.04:arm64:
 
 parts:
   charm:


### PR DESCRIPTION
# Description
Add support for 24.04 while maintaining support for 22.04. This requires charmcraft>=3.3.0.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
- [x] I have validated 24.04 is working on common sunbeam deployment