### PR TITLE
build: update track-name in publish workflow to version 1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
       description: >
         We need to know a bit more about the context in which you run the charm.
         - Are you running Juju locally, on lxd, in multipass or on some other platform?
-        - What track and channel you deployed the charm from (ie. `latest/edge` or similar).
+        - What track and channel you deployed the charm from (ie. `1/stable` or similar).
         - Version of any applicable components, like the juju snap, the model controller, lxd, microk8s, and/or multipass.
     validations:
       required: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,6 +45,6 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm-multiarch.yaml@v0
     with:
-      track-name: latest
+      track-name: 1
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -45,6 +45,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: 1/${{ env.promote-to }}
           origin-channel: 1/${{ env.promote-from }}
-          charmcraft-channel: 1/stable
+          charmcraft-channel: latest/stable
           base-channel: "22.04"
           base-architecture: ${{ github.event.inputs.arch }}

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -43,8 +43,8 @@ jobs:
         with:
           credentials: ${{ secrets.CHARMCRAFT_AUTH }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          destination-channel: latest/${{ env.promote-to }}
-          origin-channel: latest/${{ env.promote-from }}
-          charmcraft-channel: latest/stable
+          destination-channel: 1/${{ env.promote-to }}
+          origin-channel: 1/${{ env.promote-from }}
+          charmcraft-channel: 1/stable
           base-channel: "22.04"
           base-architecture: ${{ github.event.inputs.arch }}


### PR DESCRIPTION
I created a new branch for the old track (confusingly named `latest`) -- https://github.com/canonical/self-signed-certificates-operator/tree/latest

With these changes:

- This branch (`main`) should now publish to the `1/` track.
- The promote workflow should promote from and to the `1/` track.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
