### PR TITLE
chore: Replace legacy Jira URL with Webhook URL and Token in the issues (Jira Sync) workflow

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -11,9 +11,9 @@ jobs:
     steps:
       - name: Create JIRA ticket
         env:
-           ISSUE_TITLE: ${{ github.event.issue.title }}
-           ISSUE_DESCRIPTION: ${{ github.event.issue.body }}
-        run: |              
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_DESCRIPTION: ${{ github.event.issue.body }}
+        run: |
           if ${{ contains(github.event.*.labels.*.name, 'Bug') }}; then
             type=bug
           else
@@ -27,5 +27,9 @@ jobs:
                   --arg type "$type" \
                   --arg action '${{ github.event.action }}' \
                   '{title: $title, url: $url, submitter: $submitter, body: $body, type: $type, action: $action}' )
- 
-          curl -X POST -H 'Content-type: application/json' --data "${data}" "${{ secrets.JIRA_URL }}"
+
+          curl -X POST \
+            -H 'Content-Type: application/json' \
+            -H 'X-Automation-Webhook-Token: ${{ secrets.JIRA_WEBHOOK_TOKEN }}' \
+            --data "${data}" \
+            "${{ secrets.JIRA_WEBHOOK_URL }}"


### PR DESCRIPTION
# Description

Replace legacy Jira URL with Webhook URL and Token in the issues (Jira Sync) workflow

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
