### PR TITLE
fix: add xml report and rename tics workflow

### DIFF
--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: # Allows manual triggering
 
 jobs:
-  analyze-k8s:
+  analyze:
     uses: canonical/identity-credentials-workflows/.github/workflows/tics-tox.yaml@v0
     with:
       project: self-signed-certificates-operator

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,7 @@ description = Run unit tests
 commands =
     coverage run --source={[vars]src_path} -m pytest {[vars]unit_test_path} -v --tb native -s {posargs}
     coverage report
+    coverage xml
 
 [testenv:integration]
 description = Run integration tests


### PR DESCRIPTION
Workflow was failing due to missing XML file. Also renamed the workflow since it is not a "k8s" specific one.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
