### PR TITLE
chore: allow different tf provider minor versions

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.18.0"
+      version = "~> 0.18"
     }
   }
 }


### PR DESCRIPTION
# Description

`~>` in the TF provider version allows only the right-most version component to increment. Examples:
-   `~> 1.0.4`: Allows Terraform to install 1.0.5 and 1.0.10 but not 1.1.0.
-   `~> 1.1`: Allows Terraform to install 1.2 and 1.10 but not 2.0.

Here we make it possible for users to use Juju TF provider version `0.x.y`. 

## Context

A user asked us to use self-signed certificates with the TF provider 0.19 and we don't necessarily want to remove support for 0.18.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
