### PR TITLE
fix: Fixes chain order in charm

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -495,8 +495,8 @@ class SelfSignedCertificatesCharm(CharmBase):
                 certificate_signing_request=csr,
                 ca=ca_certificate,
                 chain=[
-                    ca_certificate,
                     certificate,
+                    ca_certificate,
                 ],
             ),
         )

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -307,7 +307,7 @@ class TestCharmConfigure:
             certificate=certificate,
             certificate_signing_request=requirer_csr,
             ca=provider_ca,
-            chain=[provider_ca, certificate],
+            chain=[certificate, provider_ca],
         )
         mock_set_relation_certificate.assert_called_with(
             provider_certificate=expected_provider_certificate,
@@ -400,14 +400,14 @@ class TestCharmConfigure:
             certificate=certificate_1,
             certificate_signing_request=requirer_csr_1,
             ca=provider_ca,
-            chain=[provider_ca, certificate_1],
+            chain=[certificate_1, provider_ca],
         )
         expected_provider_certificate_2 = ProviderCertificate(
             relation_id=tls_relation.id,
             certificate=certificate_2,
             certificate_signing_request=requirer_csr_2,
             ca=provider_ca,
-            chain=[provider_ca, certificate_2],
+            chain=[certificate_2, provider_ca],
         )
         mock_set_relation_certificate.assert_has_calls(
             [


### PR DESCRIPTION
# Description

The [RFC](https://datatracker.ietf.org/doc/html/rfc8446#section-4.4.2) has a strict requirement on the chain having the leaf certificate first. This PR fixes the order of the chain.

**Caution**: This is a breaking change, it would break charms that "expect wrong order". For example it would OpenSearch ([here](https://github.com/canonical/opensearch-operator/blob/2/edge/lib/charms/opensearch/v0/opensearch_tls.py#L228))
In my opinion expecting the wrong order and depending on it is wrong and can be considered a bug in the charms doing that, which makes me more comfortable with making this breaking change, but we still need to be cautious.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
