### PR TITLE
fix: Add optional flags to provides endpoints

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -54,10 +54,12 @@ parts:
 provides:
   certificates:
     interface: tls-certificates
+    optional: true
   send-ca-cert:
     interface: certificate_transfer
     description: |
       Send our CA certificate so clients can trust the CA by means of forming a relation.
+    optional: true
 
 requires:
   tracing:


### PR DESCRIPTION
# Description

## Issue

Since provides endpoints can be non-optional, can the default value of `optional` is [false](https://canonical-charmcraft.readthedocs-hosted.com/stable/reference/files/charmcraft-yaml-file/#endpoint-role-endpoint-name-optional), these endpoints are assumed non-optional.

## Solution

Set `optional` flag on provides endpoints to indicate correct optionality.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
