### PR TITLE
chore: add s390x arch support

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -32,6 +32,7 @@ base: ubuntu@24.04
 platforms:
   amd64:
   arm64:
+  s390x:
 
 parts:
   charm:


### PR DESCRIPTION
# Description

Just enables the s390x support on the charm and nothing else. I will be publishing the charm manually as an exception.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
