### PR TITLE
fix: Setup Juju and Microk8s manually

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -27,17 +27,36 @@ jobs:
         id: charm-path
         run: echo "charm_path=$(find built/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
 
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          juju-channel: 3.6/stable
-          provider: microk8s
-          channel: 1.31-strict/stable
-          lxd-channel: 5.21/stable
+      # Configuring manually instead of using the charmed-kubernetes/actions-operator@main
+      # so we can run sudo microk8s config | juju add-k8s my-k8s --client before bootstrap
+      # This workaround is needed because ARM runners are failing to setup strictly confined microk8s
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Install Juju
+        run: |
+          sudo snap install juju --channel=3.6/stable
+
+      - name: Install and setup Microk8s
+        run: |
+          sudo snap install microk8s --channel=1.32/stable --classic
+          sudo microk8s enable dns storage rbac
+
+      - name: Wait for Microk8s to be ready
+        run: |
+          sudo microk8s status --wait-ready
+
+      - name: Add Microk8s to Juju
+        run: |
+          sudo microk8s config | juju add-k8s my-k8s --client
+
+      - name: Bootstrap Juju controller
+        run: |
+          juju bootstrap my-k8s github-pr-${{ github.run_id }}-microk8s
 
       - name: Install UV and Tox
         run: |
-          pipx uninstall tox
+          pipx uninstall tox || true
           sudo snap install astral-uv --classic
           uv tool install tox --with tox-uv --force
 


### PR DESCRIPTION
# Description

Integration tests are failing on ARM because the self hosted runners are failing to bootstrap strictly confined microk8s. To workaround that we use a non-strictly confined microk8s which requires manually adding kubeconfig to Juju and since that can't be done using actions-operator we set up the environment manually.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
