### PR TITLE
fix: Run the scan workflow on push to main

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -3,7 +3,7 @@ name: Scan UV dependencies
 on:
   push:
     branches:
-      - latest
+      - main
 
 jobs:
   scan:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   scan:
-    uses: canonical/identity-credentials-workflows/.github/workflows/uv-scan.yaml@v0s
+    uses: canonical/identity-credentials-workflows/.github/workflows/uv-scan.yaml@v0


### PR DESCRIPTION
# Description

The scan for main should run when we push to main. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
