### PR TITLE
chore: Allow using the config of the base branch instead the one in default

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,4 +4,5 @@
         "https://raw.githubusercontent.com/canonical/identity-credentials-workflows/refs/heads/v0/renovate.json5"
     ],
     "baseBranchPatterns": ["main", "latest"]
+    "useBaseBranchConfig": "merge"
 }


### PR DESCRIPTION
# Description

For renovate to correctly run on the release branch "latest" we must allow it to use the config from that branch instead of the one in the default branch.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
