### PR TITLE
chore: Allow renovate to run at any time

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,58 +1,35 @@
 {
-  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: [
-    'config:recommended',
-    ':disableRateLimiting',
-    ':noUnscheduledUpdates',
-    ':semanticCommits',
-  ],
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["config:recommended", ":disableRateLimiting", ":semanticCommits"],
   automerge: true,
-  automergeStrategy: 'squash',
-  automergeType: 'pr',
+  automergeStrategy: "squash",
+  automergeType: "pr",
   platformAutomerge: true,
-  schedule: [
-    'after 1am and before 3am on monday',
-  ],
+  schedule: ["at any time"],
   lockFileMaintenance: {
     enabled: true,
-    schedule: [
-      'after 1am and before 3am on wednesday',
-    ],
+    schedule: ["at any time"],
   },
-  timezone: 'Etc/UTC',
-  enabledManagers: [
-    'pep621',
-    'github-actions',
-    'terraform',
-  ],
+  timezone: "Etc/UTC",
+  enabledManagers: ["pep621", "github-actions", "terraform"],
   packageRules: [
     {
-      matchManagers: [
-        'pep621',
-      ],
-      rangeStrategy: 'bump',
-      groupName: 'Python dependencies',
+      matchManagers: ["pep621"],
+      rangeStrategy: "bump",
+      groupName: "Python dependencies",
     },
     {
-      matchPackageNames: [
-        'pytest-asyncio',
-      ],
-      matchUpdateTypes: [
-        'minor',
-      ],
+      matchPackageNames: ["pytest-asyncio"],
+      matchUpdateTypes: ["minor"],
       enabled: false,
     },
     {
-      matchManagers: [
-        'github-actions',
-      ],
-      groupName: 'GitHub actions',
+      matchManagers: ["github-actions"],
+      groupName: "GitHub actions",
     },
     {
-      matchManagers: [
-        'terraform',
-      ],
-      groupName: 'Terraform',
+      matchManagers: ["terraform"],
+      groupName: "Terraform",
     },
   ],
 }


### PR DESCRIPTION
# Description

Allow renovate to run at any time

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
