### PR TITLE
fix: Ensure fetch_libs is set to true in TiCS Static Analysis workflow

### DIFF
--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -10,5 +10,6 @@ jobs:
     uses: canonical/identity-credentials-workflows/.github/workflows/tics-tox.yaml@v0
     with:
       project: self-signed-certificates-operator
+      fetch_libs: true
     secrets:
       TICSAUTHTOKEN: ${{ secrets.TICSAUTHTOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+coverage.xml
 .charm_tracing_buffer.raw
 build/
 *.egg-info
@@ -14,6 +15,8 @@ build/
 
 # Charmcraft
 *.charm
+# lib files are fetched with `charmcraft fetch-libs`
+lib/
 
 # Local .terraform directories
 **/.terraform/*


### PR DESCRIPTION
Fetch the libs of the project before running the TiCS analysis.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
