### PR TITLE
build: add secscan to published builds

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -17,34 +17,36 @@ on:
           - amd64
           - arm64
 
+env:
+  PROMOTE_FROM: ${{ inputs.promotion == 'edge -> beta' && 'edge' || inputs.promotion == 'beta -> candidate' && 'beta' || inputs.promotion == 'candidate -> stable' && 'candidate' || '' }}
+  PROMOTE_TO:   ${{ inputs.promotion == 'edge -> beta' && 'beta' || inputs.promotion == 'beta -> candidate' && 'candidate' || inputs.promotion == 'candidate -> stable' && 'stable' || '' }}
+  PROMOTE_ARCH: ${{ inputs.arch }}
+
 jobs:
+  scan:
+    name: Secscan
+    uses: ./.github/workflows/secscan.yaml
+    with:
+      # We have to compute the channel here again because we can't pass env variables to a reusable workflow
+      channel: ${{ inputs.promotion == 'edge -> beta' && 'edge' || inputs.promotion == 'beta -> candidate' && 'beta' || inputs.promotion == 'candidate -> stable' && 'candidate' || '' }}
+      arch: ${{ inputs.arch }}
+      create-issue: ${{ inputs.promotion == 'candidate -> stable' || inputs.promotion == 'beta -> candidate' }}
+
   promote:
     name: Promote Charm
+    needs:
+      - scan
+    if: ${{ (inputs.promotion != 'candidate -> stable') || needs.scan.outputs.secscan-return-code == '0' }}
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-      - name: Set target channel
-        env:
-          PROMOTE_FROM: ${{ github.event.inputs.promotion }}
-        run: |
-          if [ "${PROMOTE_FROM}" == "edge -> beta" ]; then
-            echo "promote-from=edge" >> ${GITHUB_ENV}
-            echo "promote-to=beta" >> ${GITHUB_ENV}
-          elif [ "${PROMOTE_FROM}" == "beta -> candidate" ]; then
-            echo "promote-from=beta" >> ${GITHUB_ENV}
-            echo "promote-to=candidate" >> ${GITHUB_ENV}
-          elif [ "${PROMOTE_FROM}" == "candidate -> stable" ]; then
-            echo "promote-from=candidate" >> ${GITHUB_ENV}
-            echo "promote-to=stable" >> ${GITHUB_ENV}
-          fi
+      - uses: actions/checkout@v5
       - name: Promote Charm
         uses: canonical/charming-actions/release-charm@2.7.0
         with:
           credentials: ${{ secrets.CHARMCRAFT_AUTH }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          destination-channel: 1/${{ env.promote-to }}
-          origin-channel: 1/${{ env.promote-from }}
+          destination-channel: 1/${{ env.PROMOTE_TO }}
+          origin-channel: 1/${{ env.PROMOTE_FROM }}
           charmcraft-channel: latest/stable
           base-channel: "24.04"
-          base-architecture: ${{ github.event.inputs.arch }}
+          base-architecture: ${{ env.PROMOTE_ARCH }}

--- a/.github/workflows/secscan.yaml
+++ b/.github/workflows/secscan.yaml
@@ -1,0 +1,55 @@
+name: secscan
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: The channel to scan (edge, beta, candidate, stable).
+        required: true
+        type: string
+      arch:
+        description: The architecture to scan (amd64, arm64).
+        required: true
+        type: string
+      create-issue:
+        description: Whether to create an issue if secscan finds a problem.
+        required: false
+        default: false
+        type: boolean
+    outputs:
+      secscan-return-code:
+        description: The result of the secscan job
+        value: ${{ jobs.secscan.outputs.secscan-return-code }}
+
+env:
+  SECSCAN_RESULTS: secscan-result.txt
+  CHARM_CHANNEL: 1/${{ inputs.channel }}
+  JUJU_CHANNEL: 3.6/stable
+
+
+jobs:
+  secscan:
+    runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
+    outputs:
+      secscan-return-code: ${{ steps.secscan.outputs.secscan-return-code }}
+    steps:
+      - name: Install dependencies and download charm
+        run: |
+          sudo snap install canonical-secscan-client
+          sudo snap connect canonical-secscan-client:home system:home
+          sudo snap install juju --channel=${{ env.JUJU_CHANNEL }}
+          echo "Downloading charm from channel ${{ env.CHARM_CHANNEL }}"
+          juju download self-signed-certificates --arch=${{ inputs.arch }} --channel=${{ env.CHARM_CHANNEL }} --filepath=self-signed-certificates.charm
+      - name: Run secscan
+        id: secscan
+        run: |
+          set +e
+          secscan-client --batch submit --scanner trivy --type package --format charm self-signed-certificates.charm --wait-and-print | tee $SECSCAN_RESULTS
+          echo "secscan-return-code=$?" >> $GITHUB_OUTPUT
+          set -e
+      - name: Create issue
+        if: steps.secscan.outputs.secscan-return-code != '0' && inputs.create-issue
+        run: |
+          echo "please check job ${{ github.run_id}}" >> $SECSCAN_RESULTS
+          gh issue create -R ${{ github.repository }} --label bug --title "Release compromised by CVE" -F $SECSCAN_RESULTS
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This change to the workflows is based on https://github.com/canonical/identity-team/blob/main/.github/workflows/_secscan.yaml

I've manually tested it multiple times here: https://github.com/canonical/self-signed-certificates-operator/actions/workflows/promote.yaml

It will run the scan, and create issues if the risk channel is `candidate` or `stable`. It won't allow publishing to `stable` with a known CVE. This might be a little too strict, but I figure we can always add an override in the future if needed.

Once this has been reviewed and merged, I plan to:

- make the necessary changes to move this to https://github.com/canonical/identity-credentials-workflows (generify)
- make similar workflows for rocks and snaps
- apply to all our other repos

-- but I didn't want to spread the changes across multiple repos for my first go / review.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
