### PR TITLE
chore: pin TF Juju provider to version = "< 1.0.0"

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.20"
+      version = "< 1.0.0"
     }
   }
 }


### PR DESCRIPTION
# Description

TF Provider v1 has breaking changes, specifically [model_uuid](https://registry.terraform.io/providers/juju/juju/latest/docs/resources/application#model_uuid-1). This PR pins the TF Juju provider version to `< 1.0.0` so that you can tag your repo with this change. This will allow users to still source your TF module for TF Juju provider `< 1.0.0`. E.g.  `source = "git::https://github.com/canonical/self-signed-certificates-operator//terraform?ref=TF_PROVIDER_V0_TAG"`, where the `TF_PROVIDER_V0_TAG` repo tag can be whatever you like.

Related:
- https://github.com/canonical/self-signed-certificates-operator/pull/460

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
