### PR TITLE
chore: Migrate libs to the ones managed by charmcraft and pypi and use the latest shared workflows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,33 +9,36 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: ${{ github.ref == 'refs/heads/main' && format('ignore-main-{0}', github.run_id) || format('{0}-{1}', github.workflow, github.ref_name) }}
   cancel-in-progress: true
 
 jobs:
-  lint-report:
-    uses: canonical/identity-credentials-workflows/.github/workflows/lint-report.yaml@v3.1.2
+  quality:
+    name: Quality
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: canonical/identity-credentials-workflows/.github/actions/prepare@v3.1.2
 
-  static-analysis:
-    name: Static analysis
-    uses: canonical/identity-credentials-workflows/.github/workflows/static-analysis.yaml@v3.1.2
-    with:
-      fetch-libs: true
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
 
-  unit-tests-with-coverage:
-    uses: canonical/identity-credentials-workflows/.github/workflows/unit-test.yaml@v3.1.2
-    with:
-      fetch-libs: true
+      - name: Fetch charmcraft libs
+        run: charmcraft fetch-libs
+
+      - uses: canonical/identity-credentials-workflows/.github/actions/code-quality@v3.1.2
+        with:
+          python-enabled: "true"
+
+      - uses: canonical/identity-credentials-workflows/.github/actions/unit-test@v3.1.2
+        with:
+          python-enabled: "true"
 
   build:
     needs:
-      - lint-report
-      - static-analysis
-      - unit-tests-with-coverage
+      - quality
     uses: canonical/identity-credentials-workflows/.github/workflows/charm-build.yaml@v3.1.2
     with:
       path: ""
@@ -43,9 +46,7 @@ jobs:
 
   build-arm:
     needs:
-      - lint-report
-      - static-analysis
-      - unit-tests-with-coverage
+      - quality
     uses: canonical/identity-credentials-workflows/.github/workflows/charm-build.yaml@v3.1.2
     with:
       path: ""
@@ -63,12 +64,12 @@ jobs:
 
   publish-charm-amd64:
     needs:
-      - lint-report
-      - static-analysis
-      - unit-tests-with-coverage
+      - quality
       - integration-test
       - build
     if: ${{ github.ref_name == 'main' }}
+    permissions:
+      contents: write
     uses: canonical/identity-credentials-workflows/.github/workflows/charm-publish.yaml@v3.1.2
     with:
       destination_channel: 1/edge
@@ -79,12 +80,12 @@ jobs:
 
   publish-charm-arm64:
     needs:
-      - lint-report
-      - static-analysis
-      - unit-tests-with-coverage
+      - quality
       - integration-test
       - build-arm
     if: ${{ github.ref_name == 'main' }}
+    permissions:
+      contents: write
     uses: canonical/identity-credentials-workflows/.github/workflows/charm-publish.yaml@v3.1.2
     with:
       destination_channel: 1/edge

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,67 +18,40 @@ concurrency:
 
 jobs:
   lint-report:
-    uses: canonical/identity-credentials-workflows/.github/workflows/lint-report.yaml@v1.3.1
+    uses: canonical/identity-credentials-workflows/.github/workflows/lint-report.yaml@v3.1.2
 
   static-analysis:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Install charmcraft
-        run: sudo snap install charmcraft --classic
-
-      - name: Fetch charmcraft libs
-        run: charmcraft fetch-libs
-
-      - name: Install uv
-        run: sudo snap install --classic astral-uv
-
-      - name: Install tox
-        run: uv tool install tox --with tox-uv
-
-      - name: Run tests using tox
-        run: |
-          tox -e static
+    name: Static analysis
+    uses: canonical/identity-credentials-workflows/.github/workflows/static-analysis.yaml@v3.1.2
+    with:
+      fetch-libs: true
 
   unit-tests-with-coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Install charmcraft
-        run: sudo snap install charmcraft --classic
-
-      - name: Fetch charmcraft libs
-        run: charmcraft fetch-libs
-
-      - name: Install uv
-        run: sudo snap install --classic astral-uv
-
-      - name: Install tox
-        run: uv tool install tox --with tox-uv
-
-      - name: Run tests using tox
-        run: |
-          tox -e unit
+    uses: canonical/identity-credentials-workflows/.github/workflows/unit-test.yaml@v3.1.2
+    with:
+      fetch-libs: true
 
   build:
     needs:
       - lint-report
       - static-analysis
       - unit-tests-with-coverage
-    uses: canonical/identity-credentials-workflows/.github/workflows/build-charm-amd.yaml@v1.3.1
+    uses: canonical/identity-credentials-workflows/.github/workflows/charm-build.yaml@v3.1.2
     with:
       path: ""
+      fetch-libs: true
 
   build-arm:
     needs:
       - lint-report
       - static-analysis
       - unit-tests-with-coverage
-    uses: canonical/identity-credentials-workflows/.github/workflows/build-charm-arm.yaml@v1.3.1
+    uses: canonical/identity-credentials-workflows/.github/workflows/charm-build.yaml@v3.1.2
     with:
       path: ""
+      arch: arm64
+      runner: '["self-hosted", "linux", "ARM64", "medium", "noble"]'
+      fetch-libs: true
 
   integration-test:
     needs:
@@ -96,7 +69,7 @@ jobs:
       - integration-test
       - build
     if: ${{ github.ref_name == 'main' }}
-    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm.yaml@v1.3.1
+    uses: canonical/identity-credentials-workflows/.github/workflows/charm-publish.yaml@v3.1.2
     with:
       destination_channel: 1/edge
       artifacts-key: ${{ needs.build.outputs.artifacts-key }}
@@ -112,7 +85,7 @@ jobs:
       - integration-test
       - build-arm
     if: ${{ github.ref_name == 'main' }}
-    uses: canonical/identity-credentials-workflows/.github/workflows/publish-charm.yaml@v1.3.1
+    uses: canonical/identity-credentials-workflows/.github/workflows/charm-publish.yaml@v3.1.2
     with:
       destination_channel: 1/edge
       artifacts-key: ${{ needs.build-arm.outputs.artifacts-key }}

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Fetch charm libraries
         run: |
           sudo snap install charmcraft --classic --channel latest/stable
-          charmcraft fetch-lib
+          charmcraft fetch-libs
         env:
           CHARMCRAFT_AUTH: "${{ secrets.CHARMCRAFT_AUTH }}"
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -153,8 +153,6 @@ actions:
     description: Creates a new private key and a new CA certificate and revokes all issued certificates.
 
 charm-libs:
-  - lib: certificate_transfer_interface.certificate_transfer
-    version: "1.15"
   - lib: tempo_coordinator_k8s.charm_tracing
     version: "0.12"
   - lib: tempo_coordinator_k8s.tracing

--- a/justfile
+++ b/justfile
@@ -1,0 +1,7 @@
+# Self-Signed Certificates Operator justfile
+#
+# In CI, common.just is merged into this file by the prepare action.
+# For local development, install just (https://just.systems) and run:
+#   just --list
+
+import? "https://raw.githubusercontent.com/canonical/identity-credentials-workflows/refs/tags/v3.1.2/common.just"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,12 @@ version = "0.1.0"
 requires-python = ">=3.10"
 
 dependencies = [
+    "charmlibs-interfaces-certificate-transfer>=1.0.0",
+    "charmlibs-interfaces-tls-certificates~=1.8",
     "jsonschema",
     "ops >=3.6.0",
     "opentelemetry-exporter-otlp-proto-http",
     "pydantic==2.12.5",
-    "charmlibs-interfaces-tls-certificates~=1.8"
 ]
 
 [dependency-groups]

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,6 +8,9 @@ import logging
 from datetime import datetime, timedelta
 from typing import Any, Iterator, Optional, cast
 
+from charmlibs.interfaces.certificate_transfer import (
+    CertificateTransferProvides,
+)
 from charmlibs.interfaces.tls_certificates import (
     Certificate,
     CertificateSigningRequest,
@@ -18,9 +21,6 @@ from charmlibs.interfaces.tls_certificates import (
     generate_ca,
     generate_certificate,
     generate_private_key,
-)
-from charms.certificate_transfer_interface.v1.certificate_transfer import (
-    CertificateTransferProvides,
 )
 from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
 from charms.tempo_coordinator_k8s.v0.tracing import TracingEndpointRequirer, charm_tracing_config

--- a/uv.lock
+++ b/uv.lock
@@ -225,17 +225,30 @@ wheels = [
 ]
 
 [[package]]
+name = "charmlibs-interfaces-certificate-transfer"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ops" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/e815e2c9d8ad8e091b31301af54d1cc626bdaf4f25b6e60f33ed52cf7cd7/charmlibs_interfaces_certificate_transfer-1.0.0.tar.gz", hash = "sha256:53f230abb2b42e7c23929a2d99321b1f0e226f20595609105fbd0528fcc3cf24", size = 42167, upload-time = "2026-02-23T18:34:18.971Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/bb/f5ed4a41c154723bd6ea4b983395d6db67d4a3c7dd87bde8ea6848159e63/charmlibs_interfaces_certificate_transfer-1.0.0-py3-none-any.whl", hash = "sha256:21cef05199a9efa459be43207e042be6792605b70e742d8b0fed6f09c0cb232d", size = 8435, upload-time = "2026-02-23T18:34:17.876Z" },
+]
+
+[[package]]
 name = "charmlibs-interfaces-tls-certificates"
-version = "1.8.1"
+version = "1.8.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "ops" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/7e/166af1e71f2bf96482845a1806dc345cbc5507134a99ccbbae297f174e4b/charmlibs_interfaces_tls_certificates-1.8.1.tar.gz", hash = "sha256:f2bfabf3a3b4c18034941771733177b30e4742c06d7742d4bb30da6ead953f43", size = 148059, upload-time = "2026-02-27T13:46:50.086Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/b0/24342009af662f52f83d163852d43d53e9e0c3fb629feeeda5eeb739c03e/charmlibs_interfaces_tls_certificates-1.8.3.tar.gz", hash = "sha256:6bc35ee330681f2e0c58cf67e41133b144f3281f73d27293714c9ca918ee7cbc", size = 110247, upload-time = "2026-06-05T10:08:01.55Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/17/1d1b0083800f4cc20f42e5d2763521d93975376499565c62da5276a80629/charmlibs_interfaces_tls_certificates-1.8.1-py3-none-any.whl", hash = "sha256:8e8fe047e02515d76f57a1d019056d72ce8c859c2ffb39a1e379cfc11fc048e6", size = 28208, upload-time = "2026-02-27T13:46:48.959Z" },
+    { url = "https://files.pythonhosted.org/packages/72/3f/168d8416060557dca7ada03d160b3efbecb21cdda89ce262524ee5b3518e/charmlibs_interfaces_tls_certificates-1.8.3-py3-none-any.whl", hash = "sha256:fa0aa150b4e4513d439c7afb7eb0ceaf00363671143b27b09382758deea8a0cc", size = 28293, upload-time = "2026-06-05T10:08:00.383Z" },
 ]
 
 [[package]]
@@ -1460,6 +1473,7 @@ name = "self-signed-certificates-operator"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "charmlibs-interfaces-certificate-transfer" },
     { name = "charmlibs-interfaces-tls-certificates" },
     { name = "jsonschema" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
@@ -1484,6 +1498,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "charmlibs-interfaces-certificate-transfer", specifier = ">=1.0.0" },
     { name = "charmlibs-interfaces-tls-certificates", specifier = "~=1.8" },
     { name = "jsonschema" },
     { name = "opentelemetry-exporter-otlp-proto-http" },


### PR DESCRIPTION
# Description

Migrate libs to the ones managed by charmcraft and pypi and use the latest shared workflows

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
